### PR TITLE
Add "StartProcess" to process model execution namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# lock-files
+package-lock.json
+yarn.lock
+
+# build directories
+dist
+
+# auto-generated schemas and documentation
+doc
+schemas
+
+# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
+.grunt
+
+# Dependency directories
+node_modules
+
+# Optional npm cache directory
+.npm
+
+# OSX-finder info-files
+*.DS_Store
+
+# IDE configs
+.vscode
+.idea/
+*.iml
+*.iws
+.classpath
+.project
+.settings/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,25 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
+.grunt
+
+# Dependency directories
+node_modules
+
+# Optional npm cache directory
+.npm
+
+# OSX-finder info-files
+*.DS_Store
+
+# IDE configs
+.vscode
+.idea/
+*.iml
+*.iws
+.classpath
+.project
+.settings/

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,42 @@
+#### Describe your issue
+
+> Describe the issue or ask your question regarding this module.
+> Provide as much relevant information as you can. If you're not sure if something
+> is relevant or not, include it as well!
+> 
+> Logs and screenshots are very welcome!
+
+#### How can others reproduce the issue?
+
+> Describe how others can reproduce this issue as precisely as possible.
+> 
+> If you can't reproduce the issue, let us know what you tried!
+> 
+> You can remove this section if the issue isn't something reproducable
+> (for example for certain questions or feature requests).
+
+#### Possible solution
+
+> If you have a possible solution to this issue or an idea that might
+> help us to find one, describe it here. Let us know what you tried!
+>
+> You can remove this section if it'd be empty.
+
+#### What's your setup
+
+- OS (`Windows/OS X/Linux` + `version`):
+- Node (`node --version`):
+- NPM (`npm --version`):
+- Docker (`docker version --format '{{.Server.Version}}'`):
+
+> You can remove this section if it's irrelevant to the issue
+> (for example for certain questions or feature requests).
+
+#### Issue checklist
+
+Please check the boxes in this list after submitting your Issue:
+
+- [ ] I've checked if this issue already exists
+- [ ] I've included all the information that i think is relevant
+- [ ] I've added logs and/or screenshots (if applicable)
+- [ ] I've mentioned PRs and issues that relate to this one

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,8 +48,6 @@ pipeline {
       steps {
         sh('node --version')
         sh('npm run build')
-        sh('npm run build-schemas')
-        sh('npm run build-doc')
       }
     }
     stage('test') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,127 @@
+#!/usr/bin/env groovy
+
+def cleanup_workspace() {
+  cleanWs()
+  dir("${env.WORKSPACE}@tmp") {
+    deleteDir()
+  }
+  dir("${env.WORKSPACE}@script") {
+    deleteDir()
+  }
+  dir("${env.WORKSPACE}@script@tmp") {
+    deleteDir()
+  }
+}
+
+pipeline {
+  agent any
+  tools {
+    nodejs "node-lts"
+  }
+  environment {
+    NPM_RC_FILE = 'process-engine-ci-token'
+    NODE_JS_VERSION = 'node-lts'
+  }
+
+  stages {
+    stage('prepare') {
+      steps {
+        script {
+          raw_package_version = sh(script: 'node --print --eval "require(\'./package.json\').version"', returnStdout: true).trim()
+          package_version = raw_package_version.trim()
+          echo("Package version is '${package_version}'")
+        }
+        nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {
+          sh('node --version')
+          sh('npm install --ignore-scripts')
+        }
+      }
+    }
+    stage('lint') {
+      steps {
+        sh('node --version')
+        /* we do not want the linting to cause a failed build */
+        sh('npm run lint || true')
+      }
+    }
+    stage('build') {
+      steps {
+        sh('node --version')
+        sh('npm run build')
+        sh('npm run build-schemas')
+        sh('npm run build-doc')
+      }
+    }
+    stage('test') {
+      steps {
+        sh('node --version')
+        sh('npm run test')
+      }
+    }
+    stage('publish') {
+      steps {
+        script {
+          def branch = env.BRANCH_NAME;
+          def branch_is_master = branch == 'master';
+          def new_commit = env.GIT_PREVIOUS_COMMIT != env.GIT_COMMIT;
+
+          if (branch_is_master) {
+            if (new_commit) {
+              script {
+                // let the build fail if the version does not match normal semver
+                def semver_matcher = package_version =~ /\d+\.\d+\.\d+/;
+                def is_version_not_semver = semver_matcher.matches() == false;
+                if (is_version_not_semver) {
+                  error('Only non RC Versions are allowed in master')
+                }
+              }
+
+              def raw_package_name = sh(script: 'node --print --eval "require(\'./package.json\').name"', returnStdout: true).trim()
+              def current_published_version = sh(script: "npm show ${raw_package_name} version", returnStdout: true).trim();
+              def version_has_changed = current_published_version != raw_package_version;
+
+              if (version_has_changed) {
+                nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {
+                  sh('node --version')
+                  sh('npm publish --ignore-scripts')
+                }
+              } else {
+                println 'Skipping publish for this version. Version unchanged.'
+              }
+            }
+
+          } else {
+            // when not on master, publish a prerelease based on the package version, the
+            // current git commit and the build number.
+            // the published version gets tagged as the branch name.
+            def first_seven_digits_of_git_hash = env.GIT_COMMIT.substring(0, 8);
+            def publish_version = "${package_version}-${first_seven_digits_of_git_hash}-b${env.BUILD_NUMBER}";
+            def publish_tag = branch.replace("/", "~");
+
+            nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {
+              sh('node --version')
+              sh("npm version ${publish_version} --no-git-tag-version --force")
+              sh("npm publish --tag ${publish_tag} --ignore-scripts")
+            }
+          }
+        }
+      }
+    }
+    stage('cleanup') {
+      steps {
+        script {
+          // this stage just exists, so the cleanup-work that happens in the post-script
+          // will show up in its own stage in Blue Ocean
+          sh(script: ':', returnStdout: true);
+        }
+      }
+    }
+  }
+  post {
+    always {
+      script {
+        cleanup_workspace();
+      }
+    }
+  }
+}

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## What did you change?
+
+> Describe the changes introduced by this PR.
+>
+> Fixes # (issue, if applicable)
+
+## How can others test the changes?
+
+> Describe how others can test your changes (you can remove this section for typo fixes etc.)
+
+## PR-Checklist
+
+Please check the boxes in this list after submitting your PR:
+
+- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
+- [ ] I've tested **all** changes included in this PR.
+- [ ] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
+- [ ] I've merged the `develop` branch into my branch before finishing this PR.
+- [ ] I've **not added any other changes** than the ones described above.
+- [ ] I've mentioned all **PRs, which relate to this one**

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# management_api_client

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const gulptraum = require('gulptraum');
+const gulptraumTypescriptPlugin = require('gulptraum-typescript');
+const tsconfig = require('tsconfig');
+
+const buildSystemConfig = {
+  suppressErrorsForTasks: ['lint'],
+};
+
+const buildSystem = new gulptraum.BuildSystem(buildSystemConfig);
+
+buildSystem.config = buildSystemConfig;
+
+const tsConfigObj = tsconfig.loadSync('.');
+
+const typeScriptConfig = Object.assign({
+  compileToModules: ['commonjs']
+}, tsConfigObj.config);
+
+const gulp = require('gulp');
+
+buildSystem
+  .registerPlugin('typescript', gulptraumTypescriptPlugin, typeScriptConfig)
+  .registerTasks(gulp);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
     "url": "https://github.com/process-engine/management_api_client/issues"
   },
   "homepage": "https://github.com/process-engine/management_api_client#readme",
+  "dependencies": {
+    "@essential-projects/http_contracts": "^2.0.1",
+    "@essential-projects/errors_ts": "^1.1.0",
+    "@process-engine/management_api_contracts": "^0.1.0"
+  },
   "devDependencies": {
     "@essential-projects/tslint-config": "1.0.0",
     "@types/express": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@process-engine/management_api_client",
+  "version": "0.1.0",
+  "description": "client implementation for using the process-engine.io Management API",
+  "main": "dist/commonjs/index.js",
+  "typings": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/process-engine/management_api_client.git"
+  },
+  "author": "",
+  "contributors": [
+    "Sebastian Meier <sebastian.meier@5minds.de>"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/process-engine/management_api_client/issues"
+  },
+  "homepage": "https://github.com/process-engine/management_api_client#readme",
+  "devDependencies": {
+    "@essential-projects/tslint-config": "1.0.0",
+    "@types/express": "^4.11.0",
+    "@types/node": "^8.0.27",
+    "gulp": "^3.9.1",
+    "gulptraum": "^2.3.0",
+    "gulptraum-typescript": "^1.5.0",
+    "tsconfig": "^7.0.0",
+    "tslint": "^5.10.0",
+    "typescript": "^2.8.3"
+  },
+  "scripts": {
+    "build": "gulp build",
+    "prepare": "npm run build",
+    "lint": "gulp lint",
+    "test": "gulp test"
+  }
+}

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -1,0 +1,80 @@
+import {IHttpClient, IRequestOptions, IResponse} from '@essential-projects/http_contracts';
+import {
+  IManagementApiAccessor,
+  ManagementContext,
+  ProcessModelExecution,
+  restSettings,
+} from '@process-engine/management_api_contracts';
+
+export class ExternalAccessor implements IManagementApiAccessor {
+
+  private baseUrl: string = 'api/management/v1';
+
+  private _httpClient: IHttpClient = undefined;
+
+  constructor(httpClient: IHttpClient) {
+    this._httpClient = httpClient;
+  }
+
+  public get httpClient(): IHttpClient {
+    return this._httpClient;
+  }
+
+  public async startProcessInstance(context: ManagementContext,
+                                    processModelKey: string,
+                                    startEventKey: string,
+                                    payload: ProcessModelExecution.ProcessStartRequestPayload,
+                                    startCallbackType: ProcessModelExecution.StartCallbackType =
+                                      ProcessModelExecution.StartCallbackType.CallbackOnProcessInstanceCreated,
+                                    endEventKey?: string,
+                                  ): Promise<ProcessModelExecution.ProcessStartResponsePayload> {
+
+    const url: string = this._buildStartProcessInstanceUrl(processModelKey, startEventKey, startCallbackType, endEventKey);
+
+    const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(context);
+
+    const httpResponse: IResponse<ProcessModelExecution.ProcessStartResponsePayload> =
+      await this.httpClient.post<ProcessModelExecution.ProcessStartRequestPayload,
+        ProcessModelExecution.ProcessStartResponsePayload>(url, payload, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  private _buildStartProcessInstanceUrl(processModelKey: string,
+                                        startEventKey: string,
+                                        startCallbackType: ProcessModelExecution.StartCallbackType,
+                                        endEventKey: string): string {
+
+    let url: string = restSettings.paths.startProcessInstance
+      .replace(restSettings.params.processModelKey, processModelKey)
+      .replace(restSettings.params.startEventKey, startEventKey);
+
+    url = `${url}?start_callback_type=${startCallbackType}`;
+
+    if (startCallbackType === ProcessModelExecution.StartCallbackType.CallbackOnEndEventReached) {
+      url = `${url}&end_event_key=${endEventKey}`;
+    }
+
+    url = this._applyBaseUrl(url);
+
+    return url;
+  }
+
+  private _createRequestAuthHeaders(context: ManagementContext): IRequestOptions {
+    if (context.identity === undefined || context.identity === null) {
+      return {};
+    }
+
+    const requestAuthHeaders: IRequestOptions = {
+      headers: {
+        Authorization: `Bearer ${context.identity}`,
+      },
+    };
+
+    return requestAuthHeaders;
+  }
+
+  private _applyBaseUrl(url: string): string {
+    return `${this.baseUrl}${url}`;
+  }
+}

--- a/src/accessors/index.ts
+++ b/src/accessors/index.ts
@@ -1,0 +1,2 @@
+export * from './external_accessor';
+export * from './internal_accessor';

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -1,0 +1,44 @@
+import {
+  IManagementApiAccessor,
+  IManagementApiService,
+  ManagementContext,
+  ProcessModelExecution,
+} from '@process-engine/management_api_contracts';
+
+import {UnauthorizedError} from '@essential-projects/errors_ts';
+
+export class InternalAccessor implements IManagementApiAccessor {
+
+  private _managementApiService: IManagementApiService = undefined;
+
+  constructor(managementApiService: IManagementApiService) {
+    this._managementApiService = managementApiService;
+  }
+
+  public get managementApiService(): IManagementApiService {
+    return this._managementApiService;
+  }
+
+  public async startProcessInstance(context: ManagementContext,
+                                    processModelKey: string,
+                                    startEventKey: string,
+                                    payload: ProcessModelExecution.ProcessStartRequestPayload,
+                                    startCallbackType: ProcessModelExecution.StartCallbackType =
+                                      ProcessModelExecution.StartCallbackType.CallbackOnProcessInstanceCreated,
+                                    endEventKey?: string,
+                                  ): Promise<ProcessModelExecution.ProcessStartResponsePayload> {
+
+    this._ensureIsAuthorized(context);
+
+    return this.managementApiService.startProcessInstance(context, processModelKey, startEventKey, payload, startCallbackType, endEventKey);
+  }
+
+  private _ensureIsAuthorized(context: ManagementContext): void {
+
+    // Note: When using an external accessor, this check is performed by the ConsumerApiHttp module.
+    // Since that component is bypassed by the internal accessor, we need to perform this check here.
+    if (!context || !context.identity) {
+      throw new UnauthorizedError('No auth token provided!');
+    }
+  }
+}

--- a/src/management_api_client_service.ts
+++ b/src/management_api_client_service.ts
@@ -1,0 +1,41 @@
+import * as EssentialProjectErrors from '@essential-projects/errors_ts';
+import {
+  IManagementApiAccessor,
+  IManagementApiService,
+  ManagementContext,
+  ProcessModelExecution,
+} from '@process-engine/management_api_contracts';
+
+export class ManagementApiClientService implements IManagementApiService {
+
+  private _managementApiAccessor: IManagementApiAccessor = undefined;
+
+  constructor(managementApiAccessor: IManagementApiAccessor) {
+    this._managementApiAccessor = managementApiAccessor;
+  }
+
+  public get managementApiAccessor(): IManagementApiAccessor {
+    return this._managementApiAccessor;
+  }
+
+  public async startProcessInstance(context: ManagementContext,
+                                    processModelKey: string,
+                                    startEventKey: string,
+                                    payload: ProcessModelExecution.ProcessStartRequestPayload,
+                                    startCallbackType: ProcessModelExecution.StartCallbackType =
+                                      ProcessModelExecution.StartCallbackType.CallbackOnProcessInstanceCreated,
+                                    endEventKey?: string,
+                                  ): Promise<ProcessModelExecution.ProcessStartResponsePayload> {
+
+    if (!Object.values(ProcessModelExecution.StartCallbackType).includes(startCallbackType)) {
+      throw new EssentialProjectErrors.BadRequestError(`${startCallbackType} is not a valid return option!`);
+    }
+
+    if (startCallbackType === ProcessModelExecution.StartCallbackType.CallbackOnEndEventReached && !endEventKey) {
+      throw new EssentialProjectErrors.BadRequestError(`Must provide an EndEventKey, when using callback type 'CallbackOnEndEventReached'!`);
+    }
+
+    return this.managementApiAccessor.startProcessInstance(context, processModelKey, startEventKey, payload, startCallbackType, endEventKey);
+  }
+
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "typingOptions": {
+    "enableAutoDiscovery": true
+  },
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "jsx": "react",
+    "lib": [
+      "es2017",
+      "dom"
+    ],
+    "sourceMap": true,
+    "downlevelIteration": true,
+    "experimentalDecorators": true
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@essential-projects/tslint-config"
+}


### PR DESCRIPTION
Depends on:
https://github.com/process-engine/management_api_contracts/pull/1

## What did you change?

This PR marks the first feature in the ManagementAPI.

It is a duplicate behavior of the one implemented in the ConsumerAPI counterpart.
A main difference is the use of namespaces to dissect functional parts of the API from each other.

This PR is also meant to be the first example of how to use namespaces for such a scenario.

## How can others test the changes?

Currently there is no integration test setup for the ManagementAPI.
This will follow after a manual integrative test.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
