### PR TITLE
Feature/add support for querying active correlations

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@essential-projects/http_contracts": "^2.0.1",
     "@essential-projects/errors_ts": "^1.3.0",
-    "@process-engine/management_api_contracts": "feature~add_support_for_querying_active_correlations"
+    "@process-engine/management_api_contracts": "^0.5.0"
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "client implementation for using the process-engine.io Management API",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@essential-projects/http_contracts": "^2.0.1",
     "@essential-projects/errors_ts": "^1.3.0",
-    "@process-engine/management_api_contracts": "^0.3.0"
+    "@process-engine/management_api_contracts": "feature~add_support_for_querying_active_correlations"
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "1.0.0",

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -1,5 +1,6 @@
 import {IHttpClient, IRequestOptions, IResponse} from '@essential-projects/http_contracts';
 import {
+  Correlation,
   EventList,
   IManagementApiAccessor,
   ManagementContext,
@@ -21,6 +22,17 @@ export class ExternalAccessor implements IManagementApiAccessor {
 
   public get httpClient(): IHttpClient {
     return this._httpClient;
+  }
+
+  public async getAllActiveCorrelations(context: ManagementContext): Promise<Array<Correlation>> {
+
+    const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(context);
+
+    const url: string = this._applyBaseUrl(restSettings.paths.activeCorrelations);
+
+    const httpResponse: IResponse<Array<Correlation>> = await this.httpClient.get<Array<Correlation>>(url, requestAuthHeaders);
+
+    return httpResponse.result;
   }
 
   public async getProcessModels(context: ManagementContext): Promise<ProcessModelExecution.ProcessModelList> {

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -1,4 +1,5 @@
 import {
+  Correlation,
   EventList,
   IManagementApiAccessor,
   IManagementApiService,
@@ -20,6 +21,13 @@ export class InternalAccessor implements IManagementApiAccessor {
 
   public get managementApiService(): IManagementApiService {
     return this._managementApiService;
+  }
+
+  public async getAllActiveCorrelations(context: ManagementContext): Promise<Array<Correlation>> {
+
+    this._ensureIsAuthorized(context);
+
+    return this.managementApiService.getAllActiveCorrelations(context);
   }
 
   public async getProcessModels(context: ManagementContext): Promise<ProcessModelExecution.ProcessModelList> {

--- a/src/management_api_client_service.ts
+++ b/src/management_api_client_service.ts
@@ -1,5 +1,6 @@
 import * as EssentialProjectErrors from '@essential-projects/errors_ts';
 import {
+  Correlation,
   EventList,
   IManagementApiAccessor,
   IManagementApiService,
@@ -19,6 +20,11 @@ export class ManagementApiClientService implements IManagementApiService {
 
   public get managementApiAccessor(): IManagementApiAccessor {
     return this._managementApiAccessor;
+  }
+
+  public async getAllActiveCorrelations(context: ManagementContext): Promise<Array<Correlation>> {
+
+    return this.managementApiAccessor.getAllActiveCorrelations(context);
   }
 
   public async getProcessModels(context: ManagementContext): Promise<ProcessModelExecution.ProcessModelList> {


### PR DESCRIPTION
Closes #4 

## What did you change?

Add an implementation for the `getAllActiveCorrelations` method to the client service and its accessors.

## How can others test the changes?

Use the client to retrieve all active correlations.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
