### PR TITLE
♻️ Refactor socket io handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_client",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "client implementation for using the process-engine.io Management API",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/http_contracts": "~2.3.0",
-    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling",
+    "@essential-projects/iam_contracts": "~3.4.0",
     "@process-engine/management_api_contracts": "feature~refactor_socket_io_handling",
     "socket.io-client": "~2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
   },
   "homepage": "https://github.com/process-engine/management_api_client#readme",
   "dependencies": {
-    "@essential-projects/http_contracts": "~2.3.0",
     "@essential-projects/errors_ts": "~1.4.0",
-    "@process-engine/management_api_contracts": "~3.0.0",
+    "@essential-projects/http_contracts": "~2.3.0",
+    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling",
+    "@process-engine/management_api_contracts": "feature~refactor_socket_io_handling",
     "socket.io-client": "~2.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/http_contracts": "~2.3.0",
     "@essential-projects/iam_contracts": "~3.4.0",
-    "@process-engine/management_api_contracts": "feature~refactor_socket_io_handling",
+    "@process-engine/management_api_contracts": "~4.0.0",
     "socket.io-client": "~2.2.0"
   },
   "devDependencies": {

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -58,12 +58,32 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     this._socket.on(socketSettings.paths.userTaskFinished, callback); // TODO
   }
 
+  public async onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<any> {
+    this._ensureIsAuthorized(identity);
+    this._socket.on(socketSettings.paths.userTaskWaiting, callback); // TODO
+  }
+
+  public async onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<any> {
+    this._ensureIsAuthorized(identity);
+    this._socket.on(socketSettings.paths.userTaskFinished, callback); // TODO
+  }
+
   public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
     this._socket.on(socketSettings.paths.manualTaskWaiting, callback); // TODO
   }
 
   public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<any> {
+    this._ensureIsAuthorized(identity);
+    this._socket.on(socketSettings.paths.manualTaskFinished, callback); // TODO
+  }
+
+  public async onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<any> {
+    this._ensureIsAuthorized(identity);
+    this._socket.on(socketSettings.paths.manualTaskWaiting, callback); // TODO
+  }
+
+  public async onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
     this._socket.on(socketSettings.paths.manualTaskFinished, callback); // TODO
   }

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -41,7 +41,10 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
   // Notifications
   public initializeSocket(identity: IIdentity): void {
 
-    this._ensureIsAuthorized(identity);
+    const noAuthTokenProvided: boolean = !identity || typeof identity.token !== 'string';
+    if (noAuthTokenProvided) {
+      throw new UnauthorizedError('No auth token provided!');
+    }
 
     const socketUrl: string = `${this.config.socketUrl}/${socketSettings.namespace}`;
     const socketIoOptions: SocketIOClient.ConnectOpts = {
@@ -66,7 +69,6 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
 
     return this._createSocketIoSubscription(socketSettings.paths.userTaskWaiting, callback, subscribeOnce);
   }
@@ -76,7 +78,6 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
 
     return this._createSocketIoSubscription(socketSettings.paths.userTaskFinished, callback, subscribeOnce);
   }
@@ -86,7 +87,6 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
 
     const socketEventName: string = socketSettings.paths.userTaskForIdentityWaiting
       .replace(socketSettings.pathParams.userId, identity.userId);
@@ -99,7 +99,6 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
 
     const socketEventName: string = socketSettings.paths.userTaskForIdentityFinished
       .replace(socketSettings.pathParams.userId, identity.userId);
@@ -112,7 +111,6 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
 
     return this._createSocketIoSubscription(socketSettings.paths.processTerminated, callback, subscribeOnce);
   }
@@ -122,7 +120,6 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
 
     return this._createSocketIoSubscription(socketSettings.paths.processStarted, callback, subscribeOnce);
   }
@@ -133,7 +130,7 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     processModelId: string,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
+
     const eventName: string = socketSettings.paths.processInstanceStarted
       .replace(socketSettings.pathParams.processModelId, processModelId);
 
@@ -145,7 +142,6 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
 
     return this._createSocketIoSubscription(socketSettings.paths.manualTaskWaiting, callback, subscribeOnce);
   }
@@ -155,7 +151,6 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
 
     return this._createSocketIoSubscription(socketSettings.paths.manualTaskFinished, callback, subscribeOnce);
   }
@@ -165,7 +160,6 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
 
     const socketEventName: string = socketSettings.paths.manualTaskForIdentityWaiting
       .replace(socketSettings.pathParams.userId, identity.userId);
@@ -178,7 +172,6 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
 
     const socketEventName: string = socketSettings.paths.manualTaskForIdentityFinished
       .replace(socketSettings.pathParams.userId, identity.userId);
@@ -191,13 +184,11 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     callback: Messages.CallbackTypes.OnProcessEndedCallback,
     subscribeOnce: boolean = false,
   ): Promise<any> {
-    this._ensureIsAuthorized(identity);
 
     return this._createSocketIoSubscription(socketSettings.paths.processEnded, callback, subscribeOnce);
   }
 
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
-    this._ensureIsAuthorized(identity);
 
     const callbackToRemove: any = this._subscriptionCollection[subscription.id];
 
@@ -767,13 +758,6 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
 
   private _applyBaseUrl(url: string): string {
     return `${this.baseUrl}${url}`;
-  }
-
-  private _ensureIsAuthorized(identity: IIdentity): void {
-    const noAuthTokenProvided: boolean = !identity || typeof identity.token !== 'string';
-    if (noAuthTokenProvided) {
-      throw new UnauthorizedError('No auth token provided!');
-    }
   }
 
   private _createSocketIoSubscription(route: string, callback: any, subscribeOnce: boolean): Subscription {

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -199,7 +199,17 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
     this._ensureIsAuthorized(identity);
 
-    return Promise.resolve(); // TODO
+    const callbackToRemove: any = this._subscriptionCollection[subscription.id];
+
+    if (!callbackToRemove) {
+      return;
+    }
+
+    this._socket.off(subscription.id, callbackToRemove);
+
+    delete this._subscriptionCollection[subscription.id];
+
+    return Promise.resolve();
   }
 
   // Correlations

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -6,14 +6,21 @@ import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IHttpClient, IRequestOptions, IResponse} from '@essential-projects/http_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
-import {DataModels, IManagementApiAccessor, Messages, restSettings, socketSettings} from '@process-engine/management_api_contracts';
+import {
+  DataModels,
+  IManagementApiAccessor,
+  IManagementSocketIoAccessor,
+  Messages,
+  restSettings,
+  socketSettings,
+} from '@process-engine/management_api_contracts';
 
-export class ExternalAccessor implements IManagementApiAccessor {
+export class ExternalAccessor implements IManagementApiAccessor, IManagementSocketIoAccessor {
 
   private baseUrl: string = 'api/management/v1';
 
-  private _socket: SocketIOClient.Socket = undefined;
-  private _httpClient: IHttpClient = undefined;
+  private _socket: SocketIOClient.Socket;
+  private _httpClient: IHttpClient;
 
   public config: any;
 
@@ -34,6 +41,11 @@ export class ExternalAccessor implements IManagementApiAccessor {
       },
     };
     this._socket = io(socketUrl, socketIoOptions);
+  }
+
+  public disconnectSocket(identity: IIdentity): void {
+    this._socket.disconnect();
+    this._socket.close();
   }
 
   public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<any> {

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -35,41 +35,41 @@ export class ExternalAccessor implements IManagementApiAccessor {
     this._socket = io(socketUrl, socketIoOptions);
   }
 
-  public onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
+  public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.userTaskWaiting, callback);
+    this._socket.on(socketSettings.paths.userTaskWaiting, callback); // TODO
   }
 
-  public onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
+  public async onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.userTaskFinished, callback);
+    this._socket.on(socketSettings.paths.userTaskFinished, callback); // TODO
   }
 
-  public onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
+  public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.manualTaskWaiting, callback);
+    this._socket.on(socketSettings.paths.manualTaskWaiting, callback); // TODO
   }
 
-  public onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
+  public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.manualTaskFinished, callback);
+    this._socket.on(socketSettings.paths.manualTaskFinished, callback); // TODO
   }
 
-  public onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): void {
+  public async onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.processTerminated, callback);
+    this._socket.on(socketSettings.paths.processTerminated, callback); // TODO
   }
 
-  public onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): void {
+  public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.processStarted, callback);
+    this._socket.on(socketSettings.paths.processStarted, callback); // TODO
   }
 
-  public onProcessWithProcessModelIdStarted(
+  public async onProcessWithProcessModelIdStarted(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
-  ): void {
+  ): Promise<any> {
     this._ensureIsAuthorized(identity);
 
     /*
@@ -78,12 +78,12 @@ export class ExternalAccessor implements IManagementApiAccessor {
     const eventName: string = socketSettings.paths.processInstanceStarted
       .replace(socketSettings.pathParams.processModelId, processModelId);
 
-    this._socket.on(eventName, callback);
+    this._socket.on(eventName, callback); // TODO
   }
 
-  public onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): void {
+  public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
-    this._socket.on(socketSettings.paths.processEnded, callback);
+    this._socket.on(socketSettings.paths.processEnded, callback); // TODO
   }
 
   // Correlations

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -300,14 +300,14 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return httpResponse.result;
   }
 
-  public async startProcessInstance(identity: IIdentity,
-                                    processModelId: string,
-                                    startEventId: string,
-                                    payload: DataModels.ProcessModels.ProcessStartRequestPayload,
-                                    startCallbackType: DataModels.ProcessModels.StartCallbackType =
-                                      DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated,
-                                    endEventId?: string,
-                                  ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
+  public async startProcessInstance(
+    identity: IIdentity,
+    processModelId: string,
+    startEventId: string,
+    payload: DataModels.ProcessModels.ProcessStartRequestPayload,
+    startCallbackType: DataModels.ProcessModels.StartCallbackType = DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated,
+    endEventId?: string,
+  ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 
     const url: string = this._buildStartProcessInstanceUrl(processModelId, startEventId, startCallbackType, endEventId);
 
@@ -332,10 +332,11 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return httpResponse.result;
   }
 
-  public async updateProcessDefinitionsByName(identity: IIdentity,
-                                              name: string,
-                                              payload: DataModels.ProcessModels.UpdateProcessDefinitionsRequestPayload,
-                                     ): Promise<void> {
+  public async updateProcessDefinitionsByName(
+    identity: IIdentity,
+    name: string,
+    payload: DataModels.ProcessModels.UpdateProcessDefinitionsRequestPayload,
+  ): Promise<void> {
 
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
@@ -449,9 +450,11 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return httpResponse.result;
   }
 
-  public async getUserTasksForProcessModelInCorrelation(identity: IIdentity,
-                                                        processModelId: string,
-                                                        correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
+  public async getUserTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
 
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
@@ -467,11 +470,13 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return httpResponse.result;
   }
 
-  public async finishUserTask(identity: IIdentity,
-                              processInstanceId: string,
-                              correlationId: string,
-                              userTaskInstanceId: string,
-                              userTaskResult: DataModels.UserTasks.UserTaskResult): Promise<void> {
+  public async finishUserTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    userTaskInstanceId: string,
+    userTaskResult: DataModels.UserTasks.UserTaskResult,
+  ): Promise<void> {
 
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
@@ -512,9 +517,11 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return httpResponse.result;
   }
 
-  public async getManualTasksForProcessModelInCorrelation(identity: IIdentity,
-                                                          processModelId: string,
-                                                          correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+  public async getManualTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
 
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
@@ -530,10 +537,12 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return httpResponse.result;
   }
 
-  public async finishManualTask(identity: IIdentity,
-                                processInstanceId: string,
-                                correlationId: string,
-                                manualTaskInstanceId: string): Promise<void> {
+  public async finishManualTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    manualTaskInstanceId: string,
+  ): Promise<void> {
 
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
@@ -566,9 +575,11 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return httpResponse.result;
   }
 
-  public async getRuntimeInformationForFlowNode(identity: IIdentity,
-                                                processModelId: string,
-                                                flowNodeId: string): Promise<DataModels.Kpi.FlowNodeRuntimeInformation> {
+  public async getRuntimeInformationForFlowNode(
+    identity: IIdentity,
+    processModelId: string,
+    flowNodeId: string,
+  ): Promise<DataModels.Kpi.FlowNodeRuntimeInformation> {
 
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
@@ -614,9 +625,11 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return httpResponse.result;
   }
 
-  public async getActiveTokensForCorrelationAndProcessModel(identity: IIdentity,
-                                                            correlationId: string,
-                                                            processModelId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
+  public async getActiveTokensForCorrelationAndProcessModel(
+    identity: IIdentity,
+    correlationId: string,
+    processModelId: string,
+  ): Promise<Array<DataModels.Kpi.ActiveToken>> {
 
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
@@ -666,10 +679,12 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return httpResponse.result;
   }
 
-  public async getTokensForFlowNodeInstance(identity: IIdentity,
-                                            correlationId: string,
-                                            processModelId: string,
-                                            flowNodeId: string): Promise<Array<DataModels.TokenHistory.TokenHistoryEntry>> {
+  public async getTokensForFlowNodeInstance(
+    identity: IIdentity,
+    correlationId: string,
+    processModelId: string,
+    flowNodeId: string,
+  ): Promise<Array<DataModels.TokenHistory.TokenHistoryEntry>> {
 
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
@@ -686,9 +701,11 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return httpResponse.result;
   }
 
-  public async getTokensForCorrelationAndProcessModel(identity: IIdentity,
-                                                      correlationId: string,
-                                                      processModelId: string): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
+  public async getTokensForCorrelationAndProcessModel(
+    identity: IIdentity,
+    correlationId: string,
+    processModelId: string,
+  ): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
 
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
@@ -704,8 +721,10 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return httpResponse.result;
   }
 
-  public async getTokensForProcessInstance(identity: IIdentity,
-                                           processInstanceId: string): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
+  public async getTokensForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+  ): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
 
     const requestAuthHeaders: IRequestOptions = this._createRequestAuthHeaders(identity);
 
@@ -720,10 +739,12 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return httpResponse.result;
   }
 
-  private _buildStartProcessInstanceUrl(processModelId: string,
-                                        startEventId: string,
-                                        startCallbackType: DataModels.ProcessModels.StartCallbackType,
-                                        endEventId: string): string {
+  private _buildStartProcessInstanceUrl(
+    processModelId: string,
+    startEventId: string,
+    startCallbackType: DataModels.ProcessModels.StartCallbackType,
+    endEventId: string,
+  ): string {
 
     let restPath: string = restSettings.paths.startProcessInstance
       .replace(restSettings.params.processModelId, processModelId)

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -30,6 +30,9 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
 
   // Notifications
   public initializeSocket(identity: IIdentity): void {
+
+    this._ensureIsAuthorized(identity);
+
     const socketUrl: string = `${this.config.socketUrl}/${socketSettings.namespace}`;
     const socketIoOptions: SocketIOClient.ConnectOpts = {
       transportOptions: {

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -2,6 +2,7 @@
 import * as io from 'socket.io-client';
 
 import {UnauthorizedError} from '@essential-projects/errors_ts';
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IHttpClient, IRequestOptions, IResponse} from '@essential-projects/http_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
@@ -84,6 +85,12 @@ export class ExternalAccessor implements IManagementApiAccessor {
   public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<any> {
     this._ensureIsAuthorized(identity);
     this._socket.on(socketSettings.paths.processEnded, callback); // TODO
+  }
+
+  public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
+    this._ensureIsAuthorized(identity);
+
+    return Promise.resolve(); // TODO
   }
 
   // Correlations

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -13,83 +13,130 @@ export class InternalAccessor implements IManagementApiAccessor {
   }
 
   // Notifications
-  public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
+  public async onUserTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._managementApiService.onUserTaskWaiting(identity, callback);
+    return this._managementApiService.onUserTaskWaiting(identity, callback, subscribeOnce);
   }
 
-  public async onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription> {
+  public async onUserTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._managementApiService.onUserTaskFinished(identity, callback);
+    return this._managementApiService.onUserTaskFinished(identity, callback, subscribeOnce);
   }
 
-  public async onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
+  public async onUserTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._managementApiService.onUserTaskForIdentityWaiting(identity, callback);
+    return this._managementApiService.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
-  public async onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription> {
+  public async onUserTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._managementApiService.onUserTaskForIdentityFinished(identity, callback);
+    return this._managementApiService.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
-  public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription> {
+  public async onManualTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._managementApiService.onManualTaskWaiting(identity, callback);
+    return this._managementApiService.onManualTaskWaiting(identity, callback, subscribeOnce);
   }
 
-  public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription> {
+  public async onManualTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._managementApiService.onManualTaskFinished(identity, callback);
+    return this._managementApiService.onManualTaskFinished(identity, callback, subscribeOnce);
   }
 
-  public async onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription> {
+  public async onManualTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._managementApiService.onManualTaskForIdentityWaiting(identity, callback);
+    return this._managementApiService.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
-  public async onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription> {
+  public async onManualTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._managementApiService.onManualTaskForIdentityFinished(identity, callback);
+    return this._managementApiService.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
-  public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription> {
+  public async onProcessStarted(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessStartedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._managementApiService.onProcessStarted(identity, callback);
+    return this._managementApiService.onProcessStarted(identity, callback, subscribeOnce);
   }
 
   public async onProcessWithProcessModelIdStarted(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._managementApiService.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
+    return this._managementApiService.onProcessWithProcessModelIdStarted(identity, callback, processModelId, subscribeOnce);
   }
 
-  public async onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription> {
+  public async onProcessTerminated(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._managementApiService.onProcessTerminated(identity, callback);
+    return this._managementApiService.onProcessTerminated(identity, callback, subscribeOnce);
   }
 
-  public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription> {
+  public async onProcessEnded(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessEndedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
-    return this._managementApiService.onProcessEnded(identity, callback);
+    return this._managementApiService.onProcessEnded(identity, callback, subscribeOnce);
   }
 
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
+    this._ensureIsAuthorized(identity);
+
     return this._managementApiService.removeSubscription(identity, subscription);
   }
 

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -1,4 +1,5 @@
 import {UnauthorizedError} from '@essential-projects/errors_ts';
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {DataModels, IManagementApi, IManagementApiAccessor, Messages} from '@process-engine/management_api_contracts';
@@ -12,48 +13,56 @@ export class InternalAccessor implements IManagementApiAccessor {
   }
 
   // Notifications
-  public onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
+  public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._managementApiService.onUserTaskWaiting(identity, callback);
+
+    return this._managementApiService.onUserTaskWaiting(identity, callback);
   }
 
-  public onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
+  public async onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._managementApiService.onUserTaskFinished(identity, callback);
+
+    return this._managementApiService.onUserTaskFinished(identity, callback);
   }
 
-  public onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
+  public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._managementApiService.onManualTaskWaiting(identity, callback);
+
+    return this._managementApiService.onManualTaskWaiting(identity, callback);
   }
 
-  public onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
+  public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._managementApiService.onManualTaskFinished(identity, callback);
+
+    return this._managementApiService.onManualTaskFinished(identity, callback);
   }
 
-  public onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): void {
+  public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._managementApiService.onProcessStarted(identity, callback);
+
+    return this._managementApiService.onProcessStarted(identity, callback);
   }
 
-  public onProcessWithProcessModelIdStarted(
+  public async onProcessWithProcessModelIdStarted(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
-  ): void {
+  ): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._managementApiService.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
+
+    return this._managementApiService.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
   }
 
-  public onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): void {
+  public async onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._managementApiService.onProcessTerminated(identity, callback);
+
+    return this._managementApiService.onProcessTerminated(identity, callback);
   }
 
-  public onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): void {
+  public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
-    this._managementApiService.onProcessEnded(identity, callback);
+
+    return this._managementApiService.onProcessEnded(identity, callback);
   }
 
   // Correlations

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -25,6 +25,18 @@ export class InternalAccessor implements IManagementApiAccessor {
     return this._managementApiService.onUserTaskFinished(identity, callback);
   }
 
+  public async onUserTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
+    return this._managementApiService.onUserTaskForIdentityWaiting(identity, callback);
+  }
+
+  public async onUserTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
+    return this._managementApiService.onUserTaskForIdentityFinished(identity, callback);
+  }
+
   public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription> {
     this._ensureIsAuthorized(identity);
 
@@ -35,6 +47,18 @@ export class InternalAccessor implements IManagementApiAccessor {
     this._ensureIsAuthorized(identity);
 
     return this._managementApiService.onManualTaskFinished(identity, callback);
+  }
+
+  public async onManualTaskForIdentityWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
+    return this._managementApiService.onManualTaskForIdentityWaiting(identity, callback);
+  }
+
+  public async onManualTaskForIdentityFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
+    return this._managementApiService.onManualTaskForIdentityFinished(identity, callback);
   }
 
   public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription> {

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -1,4 +1,3 @@
-import {UnauthorizedError} from '@essential-projects/errors_ts';
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
@@ -123,85 +122,74 @@ export class InternalAccessor implements IManagementApiAccessor {
   }
 
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
-
     return this._managementApiService.removeSubscription(identity, subscription);
   }
 
   // Correlations
   public async getAllCorrelations(identity: IIdentity): Promise<Array<DataModels.Correlations.Correlation>> {
-
     return this._managementApiService.getAllCorrelations(identity);
   }
 
   public async getActiveCorrelations(identity: IIdentity): Promise<Array<DataModels.Correlations.Correlation>> {
-
     return this._managementApiService.getActiveCorrelations(identity);
   }
 
   public async getCorrelationById(identity: IIdentity, correlationId: string): Promise<DataModels.Correlations.Correlation> {
-
     return this._managementApiService.getCorrelationById(identity, correlationId);
   }
 
   public async getCorrelationByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<DataModels.Correlations.Correlation> {
-
     return this._managementApiService.getCorrelationByProcessInstanceId(identity, processInstanceId);
   }
 
   public async getCorrelationsByProcessModelId(identity: IIdentity, processModelId: string): Promise<Array<DataModels.Correlations.Correlation>> {
-
     return this._managementApiService.getCorrelationsByProcessModelId(identity, processModelId);
   }
 
   // ProcessModels
   public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
-
     return this._managementApiService.getProcessModels(identity);
   }
 
   public async getProcessModelById(identity: IIdentity, processModelId: string): Promise<DataModels.ProcessModels.ProcessModel> {
-
     return this._managementApiService.getProcessModelById(identity, processModelId);
   }
 
-  public async startProcessInstance(identity: IIdentity,
-                                    processModelId: string,
-                                    startEventId: string,
-                                    payload: DataModels.ProcessModels.ProcessStartRequestPayload,
-                                    startCallbackType: DataModels.ProcessModels.StartCallbackType =
-                                      DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated,
-                                    endEventId?: string,
-                                  ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
+  public async startProcessInstance(
+    identity: IIdentity,
+    processModelId: string,
+    startEventId: string,
+    payload: DataModels.ProcessModels.ProcessStartRequestPayload,
+    startCallbackType: DataModels.ProcessModels.StartCallbackType = DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated,
+    endEventId?: string,
+  ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 
     return this._managementApiService.startProcessInstance(identity, processModelId, startEventId, payload, startCallbackType, endEventId);
   }
 
   public async getStartEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
-
     return this._managementApiService.getStartEventsForProcessModel(identity, processModelId);
   }
 
-  public async updateProcessDefinitionsByName(identity: IIdentity,
-                                              name: string,
-                                              payload: DataModels.ProcessModels.UpdateProcessDefinitionsRequestPayload,
-                                          ): Promise<void> {
+  public async updateProcessDefinitionsByName(
+    identity: IIdentity,
+    name: string,
+    payload: DataModels.ProcessModels.UpdateProcessDefinitionsRequestPayload,
+  ): Promise<void> {
 
     return this._managementApiService.updateProcessDefinitionsByName(identity, name, payload);
   }
 
   public async deleteProcessDefinitionsByProcessModelId(identity: IIdentity, processModelId: string): Promise<void> {
-
     return this._managementApiService.deleteProcessDefinitionsByProcessModelId(identity, processModelId);
   }
 
   // Events
   public async getWaitingEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
-
     return this._managementApiService.getWaitingEventsForProcessModel(identity, processModelId);
   }
 
   public async getWaitingEventsForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.Events.EventList> {
-
     return this._managementApiService.getWaitingEventsForCorrelation(identity, correlationId);
   }
 
@@ -215,29 +203,27 @@ export class InternalAccessor implements IManagementApiAccessor {
   }
 
   public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
-
     return this._managementApiService.triggerMessageEvent(identity, messageName, payload);
   }
 
   public async triggerSignalEvent(identity: IIdentity, signalName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
-
     return this._managementApiService.triggerSignalEvent(identity, signalName, payload);
   }
 
   // UserTasks
   public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.UserTasks.UserTaskList> {
-
     return this._managementApiService.getUserTasksForProcessModel(identity, processModelId);
   }
 
   public async getUserTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
-
     return this._managementApiService.getUserTasksForCorrelation(identity, correlationId);
   }
 
-  public async getUserTasksForProcessModelInCorrelation(identity: IIdentity,
-                                                        processModelId: string,
-                                                        correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
+  public async getUserTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
 
     return this._managementApiService.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
@@ -255,12 +241,10 @@ export class InternalAccessor implements IManagementApiAccessor {
 
   // ManualTasks
   public async getManualTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-
     return this._managementApiService.getManualTasksForProcessModel(identity, processModelId);
   }
 
   public async getManualTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-
     return this._managementApiService.getManualTasksForCorrelation(identity, correlationId);
   }
 
@@ -273,10 +257,12 @@ export class InternalAccessor implements IManagementApiAccessor {
     return this._managementApiService.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
-  public async finishManualTask(identity: IIdentity,
-                                processInstanceId: string,
-                                correlationId: string,
-                                manualTaskInstanceId: string): Promise<void> {
+  public async finishManualTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    manualTaskInstanceId: string,
+  ): Promise<void> {
 
     return this._managementApiService.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
   }
@@ -304,14 +290,18 @@ export class InternalAccessor implements IManagementApiAccessor {
 
   }
 
-  public async getActiveTokensForCorrelationAndProcessModel(identity: IIdentity,
-                                                            correlationId: string,
-                                                            processModelId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
+  public async getActiveTokensForCorrelationAndProcessModel(
+    identity: IIdentity,
+    correlationId: string,
+    processModelId: string,
+  ): Promise<Array<DataModels.Kpi.ActiveToken>> {
     return this._managementApiService.getActiveTokensForCorrelationAndProcessModel(identity, correlationId, processModelId);
   }
 
-  public async getActiveTokensForProcessInstance(identity: IIdentity,
-                                                 processInstanceId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
+  public async getActiveTokensForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+  ): Promise<Array<DataModels.Kpi.ActiveToken>> {
     return this._managementApiService.getActiveTokensForProcessInstance(identity, processInstanceId);
   }
 
@@ -342,8 +332,10 @@ export class InternalAccessor implements IManagementApiAccessor {
     return this._managementApiService.getTokensForCorrelationAndProcessModel(identity, correlationId, processModelId);
   }
 
-  public async getTokensForProcessInstance(identity: IIdentity,
-                                           processInstanceId: string): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
+  public async getTokensForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+  ): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
 
     return this._managementApiService.getTokensForProcessInstance(identity, processInstanceId);
   }

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -18,7 +18,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.onUserTaskWaiting(identity, callback, subscribeOnce);
   }
@@ -28,7 +27,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.onUserTaskFinished(identity, callback, subscribeOnce);
   }
@@ -38,7 +36,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
@@ -48,7 +45,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
@@ -58,7 +54,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.onManualTaskWaiting(identity, callback, subscribeOnce);
   }
@@ -68,7 +63,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.onManualTaskFinished(identity, callback, subscribeOnce);
   }
@@ -78,7 +72,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
@@ -88,7 +81,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
@@ -98,7 +90,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.onProcessStarted(identity, callback, subscribeOnce);
   }
@@ -109,7 +100,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     processModelId: string,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.onProcessWithProcessModelIdStarted(identity, callback, processModelId, subscribeOnce);
   }
@@ -119,7 +109,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.onProcessTerminated(identity, callback, subscribeOnce);
   }
@@ -129,13 +118,11 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnProcessEndedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.onProcessEnded(identity, callback, subscribeOnce);
   }
 
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.removeSubscription(identity, subscription);
   }
@@ -143,35 +130,25 @@ export class InternalAccessor implements IManagementApiAccessor {
   // Correlations
   public async getAllCorrelations(identity: IIdentity): Promise<Array<DataModels.Correlations.Correlation>> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getAllCorrelations(identity);
   }
 
   public async getActiveCorrelations(identity: IIdentity): Promise<Array<DataModels.Correlations.Correlation>> {
-
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.getActiveCorrelations(identity);
   }
 
   public async getCorrelationById(identity: IIdentity, correlationId: string): Promise<DataModels.Correlations.Correlation> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getCorrelationById(identity, correlationId);
   }
 
   public async getCorrelationByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<DataModels.Correlations.Correlation> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getCorrelationByProcessInstanceId(identity, processInstanceId);
   }
 
   public async getCorrelationsByProcessModelId(identity: IIdentity, processModelId: string): Promise<Array<DataModels.Correlations.Correlation>> {
-
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.getCorrelationsByProcessModelId(identity, processModelId);
   }
@@ -179,14 +156,10 @@ export class InternalAccessor implements IManagementApiAccessor {
   // ProcessModels
   public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getProcessModels(identity);
   }
 
   public async getProcessModelById(identity: IIdentity, processModelId: string): Promise<DataModels.ProcessModels.ProcessModel> {
-
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.getProcessModelById(identity, processModelId);
   }
@@ -200,14 +173,10 @@ export class InternalAccessor implements IManagementApiAccessor {
                                     endEventId?: string,
                                   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.startProcessInstance(identity, processModelId, startEventId, payload, startCallbackType, endEventId);
   }
 
   public async getStartEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
-
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.getStartEventsForProcessModel(identity, processModelId);
   }
@@ -221,7 +190,6 @@ export class InternalAccessor implements IManagementApiAccessor {
   }
 
   public async deleteProcessDefinitionsByProcessModelId(identity: IIdentity, processModelId: string): Promise<void> {
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.deleteProcessDefinitionsByProcessModelId(identity, processModelId);
   }
@@ -259,14 +227,10 @@ export class InternalAccessor implements IManagementApiAccessor {
   // UserTasks
   public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.UserTasks.UserTaskList> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getUserTasksForProcessModel(identity, processModelId);
   }
 
   public async getUserTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
-
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.getUserTasksForCorrelation(identity, correlationId);
   }
@@ -274,8 +238,6 @@ export class InternalAccessor implements IManagementApiAccessor {
   public async getUserTasksForProcessModelInCorrelation(identity: IIdentity,
                                                         processModelId: string,
                                                         correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
-
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
@@ -288,22 +250,16 @@ export class InternalAccessor implements IManagementApiAccessor {
     userTaskResult: DataModels.UserTasks.UserTaskResult,
   ): Promise<void> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.finishUserTask(identity, processInstanceId, correlationId, userTaskInstanceId, userTaskResult);
   }
 
   // ManualTasks
   public async getManualTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getManualTasksForProcessModel(identity, processModelId);
   }
 
   public async getManualTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.getManualTasksForCorrelation(identity, correlationId);
   }
@@ -314,8 +270,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     correlationId: string,
   ): Promise<DataModels.ManualTasks.ManualTaskList> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
@@ -323,8 +277,6 @@ export class InternalAccessor implements IManagementApiAccessor {
                                 processInstanceId: string,
                                 correlationId: string,
                                 manualTaskInstanceId: string): Promise<void> {
-
-    this._ensureIsAuthorized(identity);
 
     return this._managementApiService.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
   }
@@ -335,8 +287,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     processModelId: string,
   ): Promise<Array<DataModels.Kpi.FlowNodeRuntimeInformation>> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getRuntimeInformationForProcessModel(identity, processModelId);
   }
 
@@ -346,15 +296,10 @@ export class InternalAccessor implements IManagementApiAccessor {
     flowNodeId: string,
   ): Promise<DataModels.Kpi.FlowNodeRuntimeInformation> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getRuntimeInformationForFlowNode(identity, processModelId, flowNodeId);
   }
 
   public async getActiveTokensForProcessModel(identity: IIdentity, processModelId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
-
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getActiveTokensForProcessModel(identity, processModelId);
 
   }
@@ -362,31 +307,19 @@ export class InternalAccessor implements IManagementApiAccessor {
   public async getActiveTokensForCorrelationAndProcessModel(identity: IIdentity,
                                                             correlationId: string,
                                                             processModelId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
-
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getActiveTokensForCorrelationAndProcessModel(identity, correlationId, processModelId);
   }
 
   public async getActiveTokensForProcessInstance(identity: IIdentity,
                                                  processInstanceId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
-
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getActiveTokensForProcessInstance(identity, processInstanceId);
   }
 
   public async getActiveTokensForFlowNode(identity: IIdentity, flowNodeId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
-
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getActiveTokensForFlowNode(identity, flowNodeId);
   }
 
   public async getProcessModelLog(identity: IIdentity, processModelId: string, correlationId?: string): Promise<Array<DataModels.Logging.LogEntry>> {
-
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getProcessModelLog(identity, processModelId, correlationId);
   }
 
@@ -397,8 +330,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     flowNodeId: string,
   ): Promise<Array<DataModels.TokenHistory.TokenHistoryEntry>> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getTokensForFlowNodeInstance(identity, correlationId, processModelId, flowNodeId);
   }
 
@@ -408,26 +339,12 @@ export class InternalAccessor implements IManagementApiAccessor {
     processModelId: string,
   ): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getTokensForCorrelationAndProcessModel(identity, correlationId, processModelId);
   }
 
   public async getTokensForProcessInstance(identity: IIdentity,
                                            processInstanceId: string): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
 
-    this._ensureIsAuthorized(identity);
-
     return this._managementApiService.getTokensForProcessInstance(identity, processInstanceId);
-  }
-
-  private _ensureIsAuthorized(identity: IIdentity): void {
-
-    // Note: When using an external accessor, this check is performed by the ConsumerApiHttp module.
-    // Since that component is bypassed by the internal accessor, we need to perform this check here.
-    const authTokenNotProvided: boolean = !identity || typeof identity.token !== 'string';
-    if (authTokenNotProvided) {
-      throw new UnauthorizedError('No auth token provided!');
-    }
   }
 }

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -65,6 +65,10 @@ export class InternalAccessor implements IManagementApiAccessor {
     return this._managementApiService.onProcessEnded(identity, callback);
   }
 
+  public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
+    return this._managementApiService.removeSubscription(identity, subscription);
+  }
+
   // Correlations
   public async getAllCorrelations(identity: IIdentity): Promise<Array<DataModels.Correlations.Correlation>> {
 

--- a/src/management_api_client_service.ts
+++ b/src/management_api_client_service.ts
@@ -13,40 +13,101 @@ export class ManagementApiClientService implements IManagementApi {
   }
 
   // Notifications
-  public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
-    return this.managementApiAccessor.onUserTaskWaiting(identity, callback);
+  public async onUserTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiAccessor.onUserTaskWaiting(identity, callback, subscribeOnce);
   }
 
-  public async onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription> {
-    return this.managementApiAccessor.onUserTaskFinished(identity, callback);
+  public async onUserTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiAccessor.onUserTaskFinished(identity, callback, subscribeOnce);
   }
 
-  public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription> {
-    return this.managementApiAccessor.onManualTaskWaiting(identity, callback);
+  public async onUserTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiAccessor.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
-  public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription> {
-    return this.managementApiAccessor.onProcessStarted(identity, callback);
+  public async onUserTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiAccessor.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
+  }
+
+  public async onProcessTerminated(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiAccessor.onProcessTerminated(identity, callback, subscribeOnce);
+  }
+
+  public async onProcessStarted(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessStartedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiAccessor.onProcessStarted(identity, callback, subscribeOnce);
   }
 
   public async onProcessWithProcessModelIdStarted(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
+    subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    return this.managementApiAccessor.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
+    return this.managementApiAccessor.onProcessWithProcessModelIdStarted(identity, callback, processModelId, subscribeOnce);
   }
 
-  public async onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription> {
-    return this.managementApiAccessor.onProcessTerminated(identity, callback);
+  public async onManualTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiAccessor.onManualTaskWaiting(identity, callback, subscribeOnce);
   }
 
-  public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription> {
-    return this.managementApiAccessor.onManualTaskFinished(identity, callback);
+  public async onManualTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiAccessor.onManualTaskFinished(identity, callback, subscribeOnce);
   }
 
-  public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription> {
-    return this.managementApiAccessor.onProcessEnded(identity, callback);
+  public async onManualTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiAccessor.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
+  }
+
+  public async onManualTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiAccessor.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
+  }
+
+  public async onProcessEnded(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessEndedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiAccessor.onProcessEnded(identity, callback, subscribeOnce);
   }
 
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {

--- a/src/management_api_client_service.ts
+++ b/src/management_api_client_service.ts
@@ -1,4 +1,5 @@
 import * as EssentialProjectErrors from '@essential-projects/errors_ts';
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {DataModels, IManagementApi, IManagementApiAccessor, Messages} from '@process-engine/management_api_contracts';
@@ -12,40 +13,40 @@ export class ManagementApiClientService implements IManagementApi {
   }
 
   // Notifications
-  public onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void {
-    this.managementApiAccessor.onUserTaskWaiting(identity, callback);
+  public async onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription> {
+    return this.managementApiAccessor.onUserTaskWaiting(identity, callback);
   }
 
-  public onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void {
-    this.managementApiAccessor.onUserTaskFinished(identity, callback);
+  public async onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription> {
+    return this.managementApiAccessor.onUserTaskFinished(identity, callback);
   }
 
-  public onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void {
-    this.managementApiAccessor.onManualTaskWaiting(identity, callback);
+  public async onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription> {
+    return this.managementApiAccessor.onManualTaskWaiting(identity, callback);
   }
 
-  public onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): void {
-    this.managementApiAccessor.onProcessStarted(identity, callback);
+  public async onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription> {
+    return this.managementApiAccessor.onProcessStarted(identity, callback);
   }
 
-  public onProcessWithProcessModelIdStarted(
+  public async onProcessWithProcessModelIdStarted(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
-  ): void {
-    this.managementApiAccessor.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
+  ): Promise<Subscription> {
+    return this.managementApiAccessor.onProcessWithProcessModelIdStarted(identity, callback, processModelId);
   }
 
-  public onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): void {
-    this.managementApiAccessor.onProcessTerminated(identity, callback);
+  public async onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription> {
+    return this.managementApiAccessor.onProcessTerminated(identity, callback);
   }
 
-  public onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void {
-    this.managementApiAccessor.onManualTaskFinished(identity, callback);
+  public async onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription> {
+    return this.managementApiAccessor.onManualTaskFinished(identity, callback);
   }
 
-  public onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): void {
-    this.managementApiAccessor.onProcessEnded(identity, callback);
+  public async onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription> {
+    return this.managementApiAccessor.onProcessEnded(identity, callback);
   }
 
   // Correlations

--- a/src/management_api_client_service.ts
+++ b/src/management_api_client_service.ts
@@ -18,6 +18,10 @@ export class ManagementApiClientService implements IManagementApi {
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.onUserTaskWaiting(identity, callback, subscribeOnce);
   }
 
@@ -26,6 +30,8 @@ export class ManagementApiClientService implements IManagementApi {
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.onUserTaskFinished(identity, callback, subscribeOnce);
   }
 
@@ -34,6 +40,8 @@ export class ManagementApiClientService implements IManagementApi {
     callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
@@ -42,6 +50,8 @@ export class ManagementApiClientService implements IManagementApi {
     callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
@@ -50,6 +60,8 @@ export class ManagementApiClientService implements IManagementApi {
     callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.onProcessTerminated(identity, callback, subscribeOnce);
   }
 
@@ -58,6 +70,8 @@ export class ManagementApiClientService implements IManagementApi {
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.onProcessStarted(identity, callback, subscribeOnce);
   }
 
@@ -67,6 +81,8 @@ export class ManagementApiClientService implements IManagementApi {
     processModelId: string,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.onProcessWithProcessModelIdStarted(identity, callback, processModelId, subscribeOnce);
   }
 
@@ -75,6 +91,8 @@ export class ManagementApiClientService implements IManagementApi {
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.onManualTaskWaiting(identity, callback, subscribeOnce);
   }
 
@@ -83,6 +101,8 @@ export class ManagementApiClientService implements IManagementApi {
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.onManualTaskFinished(identity, callback, subscribeOnce);
   }
 
@@ -91,6 +111,8 @@ export class ManagementApiClientService implements IManagementApi {
     callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
@@ -99,6 +121,8 @@ export class ManagementApiClientService implements IManagementApi {
     callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
@@ -107,40 +131,58 @@ export class ManagementApiClientService implements IManagementApi {
     callback: Messages.CallbackTypes.OnProcessEndedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.onProcessEnded(identity, callback, subscribeOnce);
   }
 
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.removeSubscription(identity, subscription);
   }
 
   // Correlations
   public async getAllCorrelations(identity: IIdentity): Promise<Array<DataModels.Correlations.Correlation>> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getAllCorrelations(identity);
   }
 
   public async getActiveCorrelations(identity: IIdentity): Promise<Array<DataModels.Correlations.Correlation>> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getActiveCorrelations(identity);
   }
 
   public async getCorrelationById(identity: IIdentity, correlationId: string): Promise<DataModels.Correlations.Correlation> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getCorrelationById(identity, correlationId);
   }
 
   public async getCorrelationByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<DataModels.Correlations.Correlation> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getCorrelationByProcessInstanceId(identity, processInstanceId);
   }
 
   public async getCorrelationsByProcessModelId(identity: IIdentity, processModelId: string): Promise<Array<DataModels.Correlations.Correlation>> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getCorrelationsByProcessModelId(identity, processModelId);
   }
 
   // ProcessModels
   public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getProcessModels(identity);
   }
 
   public async getProcessModelById(identity: IIdentity, processModelId: string): Promise<DataModels.ProcessModels.ProcessModel> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getProcessModelById(identity, processModelId);
   }
 
@@ -152,6 +194,7 @@ export class ManagementApiClientService implements IManagementApi {
                                       DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated,
                                     endEventId?: string,
                                   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
+    this._ensureIsAuthorized(identity);
 
     if (!Object.values(DataModels.ProcessModels.StartCallbackType).includes(startCallbackType)) {
       throw new EssentialProjectErrors.BadRequestError(`${startCallbackType} is not a valid return option!`);
@@ -165,28 +208,34 @@ export class ManagementApiClientService implements IManagementApi {
   }
 
   public async getStartEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getStartEventsForProcessModel(identity, processModelId);
   }
 
   public async updateProcessDefinitionsByName(identity: IIdentity,
                                               name: string,
                                               payload: DataModels.ProcessModels.UpdateProcessDefinitionsRequestPayload): Promise<void> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.updateProcessDefinitionsByName(identity, name, payload);
   }
 
   public async deleteProcessDefinitionsByProcessModelId(identity: IIdentity, processModelId: string): Promise<void> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.deleteProcessDefinitionsByProcessModelId(identity, processModelId);
   }
 
   // Events
   public async getWaitingEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getWaitingEventsForProcessModel(identity, processModelId);
   }
 
   public async getWaitingEventsForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.Events.EventList> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getWaitingEventsForCorrelation(identity, correlationId);
   }
@@ -197,31 +246,40 @@ export class ManagementApiClientService implements IManagementApi {
     correlationId: string,
   ): Promise<DataModels.Events.EventList> {
 
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getWaitingEventsForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
   public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.triggerMessageEvent(identity, messageName, payload);
   }
 
   public async triggerSignalEvent(identity: IIdentity, signalName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.triggerSignalEvent(identity, signalName, payload);
   }
 
   // UserTasks
   public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.UserTasks.UserTaskList> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getUserTasksForProcessModel(identity, processModelId);
   }
 
   public async getUserTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getUserTasksForCorrelation(identity, correlationId);
   }
 
   public async getUserTasksForProcessModelInCorrelation(identity: IIdentity,
                                                         processModelId: string,
                                                         correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
@@ -231,22 +289,28 @@ export class ManagementApiClientService implements IManagementApi {
                               correlationId: string,
                               userTaskInstanceId: string,
                               userTaskResult: DataModels.UserTasks.UserTaskResult): Promise<void> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.finishUserTask(identity, processInstanceId, correlationId, userTaskInstanceId, userTaskResult);
   }
 
   // ManualTasks
   public async getManualTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getManualTasksForProcessModel(identity, processModelId);
   }
 
   public async getManualTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getManualTasksForCorrelation(identity, correlationId);
   }
 
   public async getManualTasksForProcessModelInCorrelation(identity: IIdentity,
                                                           processModelId: string,
                                                           correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
@@ -255,6 +319,7 @@ export class ManagementApiClientService implements IManagementApi {
                                 processInstanceId: string,
                                 correlationId: string,
                                 manualTaskInstanceId: string): Promise<void> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
   }
@@ -264,38 +329,49 @@ export class ManagementApiClientService implements IManagementApi {
     identity: IIdentity,
     processModelId: string,
   ): Promise<Array<DataModels.Kpi.FlowNodeRuntimeInformation>> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getRuntimeInformationForProcessModel(identity, processModelId);
   }
 
   public async getRuntimeInformationForFlowNode(identity: IIdentity,
                                                 processModelId: string,
                                                 flowNodeId: string): Promise<DataModels.Kpi.FlowNodeRuntimeInformation> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getRuntimeInformationForFlowNode(identity, processModelId, flowNodeId);
   }
 
   public async getActiveTokensForProcessModel(identity: IIdentity, processModelId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getActiveTokensForProcessModel(identity, processModelId);
   }
 
   public async getActiveTokensForCorrelationAndProcessModel(identity: IIdentity,
                                                             correlationId: string,
                                                             processModelId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getActiveTokensForCorrelationAndProcessModel(identity, correlationId, processModelId);
   }
 
   public async getActiveTokensForProcessInstance(identity: IIdentity,
                                                  processInstanceId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getActiveTokensForProcessInstance(identity, processInstanceId);
   }
 
   public async getActiveTokensForFlowNode(identity: IIdentity, flowNodeId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getActiveTokensForFlowNode(identity, flowNodeId);
   }
 
   public async getProcessModelLog(identity: IIdentity, processModelId: string, correlationId?: string): Promise<Array<DataModels.Logging.LogEntry>> {
+    this._ensureIsAuthorized(identity);
+
     return this.managementApiAccessor.getProcessModelLog(identity, processModelId, correlationId);
   }
 
@@ -303,6 +379,7 @@ export class ManagementApiClientService implements IManagementApi {
                                             correlationId: string,
                                             processModelId: string,
                                             flowNodeId: string): Promise<Array<DataModels.TokenHistory.TokenHistoryEntry>> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getTokensForFlowNodeInstance(identity, correlationId, processModelId, flowNodeId);
   }
@@ -310,13 +387,22 @@ export class ManagementApiClientService implements IManagementApi {
   public async getTokensForCorrelationAndProcessModel(identity: IIdentity,
                                                       correlationId: string,
                                                       processModelId: string): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getTokensForCorrelationAndProcessModel(identity, correlationId, processModelId);
   }
 
   public async getTokensForProcessInstance(identity: IIdentity,
                                            processInstanceId: string): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
+    this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getTokensForProcessInstance(identity, processInstanceId);
+  }
+
+  private _ensureIsAuthorized(identity: IIdentity): void {
+    const authTokenNotProvided: boolean = !identity || typeof identity.token !== 'string';
+    if (authTokenNotProvided) {
+      throw new EssentialProjectErrors.UnauthorizedError('No auth token provided!');
+    }
   }
 }

--- a/src/management_api_client_service.ts
+++ b/src/management_api_client_service.ts
@@ -49,6 +49,10 @@ export class ManagementApiClientService implements IManagementApi {
     return this.managementApiAccessor.onProcessEnded(identity, callback);
   }
 
+  public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
+    return this.managementApiAccessor.removeSubscription(identity, subscription);
+  }
+
   // Correlations
   public async getAllCorrelations(identity: IIdentity): Promise<Array<DataModels.Correlations.Correlation>> {
     return this.managementApiAccessor.getAllCorrelations(identity);

--- a/src/management_api_client_service.ts
+++ b/src/management_api_client_service.ts
@@ -186,14 +186,15 @@ export class ManagementApiClientService implements IManagementApi {
     return this.managementApiAccessor.getProcessModelById(identity, processModelId);
   }
 
-  public async startProcessInstance(identity: IIdentity,
-                                    processModelId: string,
-                                    startEventId: string,
-                                    payload: DataModels.ProcessModels.ProcessStartRequestPayload,
-                                    startCallbackType: DataModels.ProcessModels.StartCallbackType =
-                                      DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated,
-                                    endEventId?: string,
-                                  ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
+  public async startProcessInstance(
+    identity: IIdentity,
+    processModelId: string,
+    startEventId: string,
+    payload: DataModels.ProcessModels.ProcessStartRequestPayload,
+    startCallbackType: DataModels.ProcessModels.StartCallbackType = DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated,
+    endEventId?: string,
+  ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
+
     this._ensureIsAuthorized(identity);
 
     if (!Object.values(DataModels.ProcessModels.StartCallbackType).includes(startCallbackType)) {
@@ -213,9 +214,11 @@ export class ManagementApiClientService implements IManagementApi {
     return this.managementApiAccessor.getStartEventsForProcessModel(identity, processModelId);
   }
 
-  public async updateProcessDefinitionsByName(identity: IIdentity,
-                                              name: string,
-                                              payload: DataModels.ProcessModels.UpdateProcessDefinitionsRequestPayload): Promise<void> {
+  public async updateProcessDefinitionsByName(
+    identity: IIdentity,
+    name: string,
+    payload: DataModels.ProcessModels.UpdateProcessDefinitionsRequestPayload,
+  ): Promise<void> {
     this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.updateProcessDefinitionsByName(identity, name, payload);
@@ -276,19 +279,23 @@ export class ManagementApiClientService implements IManagementApi {
     return this.managementApiAccessor.getUserTasksForCorrelation(identity, correlationId);
   }
 
-  public async getUserTasksForProcessModelInCorrelation(identity: IIdentity,
-                                                        processModelId: string,
-                                                        correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
+  public async getUserTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+  ): Promise<DataModels.UserTasks.UserTaskList> {
     this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
-  public async finishUserTask(identity: IIdentity,
-                              processInstanceId: string,
-                              correlationId: string,
-                              userTaskInstanceId: string,
-                              userTaskResult: DataModels.UserTasks.UserTaskResult): Promise<void> {
+  public async finishUserTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    userTaskInstanceId: string,
+    userTaskResult: DataModels.UserTasks.UserTaskResult,
+  ): Promise<void> {
     this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.finishUserTask(identity, processInstanceId, correlationId, userTaskInstanceId, userTaskResult);
@@ -307,18 +314,22 @@ export class ManagementApiClientService implements IManagementApi {
     return this.managementApiAccessor.getManualTasksForCorrelation(identity, correlationId);
   }
 
-  public async getManualTasksForProcessModelInCorrelation(identity: IIdentity,
-                                                          processModelId: string,
-                                                          correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+  public async getManualTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
     this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
-  public async finishManualTask(identity: IIdentity,
-                                processInstanceId: string,
-                                correlationId: string,
-                                manualTaskInstanceId: string): Promise<void> {
+  public async finishManualTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    manualTaskInstanceId: string,
+  ): Promise<void> {
     this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
@@ -334,9 +345,11 @@ export class ManagementApiClientService implements IManagementApi {
     return this.managementApiAccessor.getRuntimeInformationForProcessModel(identity, processModelId);
   }
 
-  public async getRuntimeInformationForFlowNode(identity: IIdentity,
-                                                processModelId: string,
-                                                flowNodeId: string): Promise<DataModels.Kpi.FlowNodeRuntimeInformation> {
+  public async getRuntimeInformationForFlowNode(
+    identity: IIdentity,
+    processModelId: string,
+    flowNodeId: string,
+  ): Promise<DataModels.Kpi.FlowNodeRuntimeInformation> {
     this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getRuntimeInformationForFlowNode(identity, processModelId, flowNodeId);
@@ -348,16 +361,20 @@ export class ManagementApiClientService implements IManagementApi {
     return this.managementApiAccessor.getActiveTokensForProcessModel(identity, processModelId);
   }
 
-  public async getActiveTokensForCorrelationAndProcessModel(identity: IIdentity,
-                                                            correlationId: string,
-                                                            processModelId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
+  public async getActiveTokensForCorrelationAndProcessModel(
+    identity: IIdentity,
+    correlationId: string,
+    processModelId: string,
+  ): Promise<Array<DataModels.Kpi.ActiveToken>> {
     this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getActiveTokensForCorrelationAndProcessModel(identity, correlationId, processModelId);
   }
 
-  public async getActiveTokensForProcessInstance(identity: IIdentity,
-                                                 processInstanceId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
+  public async getActiveTokensForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+  ): Promise<Array<DataModels.Kpi.ActiveToken>> {
     this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getActiveTokensForProcessInstance(identity, processInstanceId);
@@ -375,25 +392,31 @@ export class ManagementApiClientService implements IManagementApi {
     return this.managementApiAccessor.getProcessModelLog(identity, processModelId, correlationId);
   }
 
-  public async getTokensForFlowNodeInstance(identity: IIdentity,
-                                            correlationId: string,
-                                            processModelId: string,
-                                            flowNodeId: string): Promise<Array<DataModels.TokenHistory.TokenHistoryEntry>> {
+  public async getTokensForFlowNodeInstance(
+    identity: IIdentity,
+    correlationId: string,
+    processModelId: string,
+    flowNodeId: string,
+  ): Promise<Array<DataModels.TokenHistory.TokenHistoryEntry>> {
     this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getTokensForFlowNodeInstance(identity, correlationId, processModelId, flowNodeId);
   }
 
-  public async getTokensForCorrelationAndProcessModel(identity: IIdentity,
-                                                      correlationId: string,
-                                                      processModelId: string): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
+  public async getTokensForCorrelationAndProcessModel(
+    identity: IIdentity,
+    correlationId: string,
+    processModelId: string,
+  ): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
     this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getTokensForCorrelationAndProcessModel(identity, correlationId, processModelId);
   }
 
-  public async getTokensForProcessInstance(identity: IIdentity,
-                                           processInstanceId: string): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
+  public async getTokensForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+  ): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
     this._ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getTokensForProcessInstance(identity, processInstanceId);


### PR DESCRIPTION
**Changes:**

1. Implement the `removeSubscription` UseCase, which allows a user to unsubscribe from a notification.
2. Implement the `disconnectSocket` function into the ExternalAccessor, which allows a user to close a Socket.IO client.
3. Implement `subscribeOnce` flag for all notification Subscriptions. This works pretty much like the `subscribeOnce` UseCase for the EventAggregator.
4. The ExternalAccessor should no longer permit to connect to Socket.IO, if the user does not provide an identity.
5. Refactor all Notification subscription functions so that they return the created subscriptions.
6. Add identity-specific Notifications for UserTasks and ManualTasks. These were already available through the ConsumerAPI, but not yet forwarded here.
7. Move all Auth-Checks from the accessors to the client to avoid code duplication.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/#135
Part of https://github.com/process-engine/process_engine_runtime/issues/#157
Part of https://github.com/process-engine/process_engine_runtime/issues/#206

PR: #32

## How can others test the changes?

- Create a client that uses the external accessor
- Create some subscriptions for notifications
- Trigger these notifications to receive them
- Unsubscribe from a notification
- Trigger the notification again
- Notice that the callback you provided for that notification will no longer get triggered
- Dispose the ExternalAccessor
- The Socket.IO client will have disconnected from the server and is no longer able to receive notifications

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).