### PR TITLE
♻️⚡️ Allow multiple Socket.io connections for the same accessor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_client",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "client implementation for using the process-engine.io Management API",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
**Changes:**

1. Refactor the ExternalAccessor to automatically create `Socket.io` connections for each identity.
2. A convention call to `initializeSocket` upon starting the client is no longer necessary. The method only remains as a convenience function, in case you want to use the client for only one identity.

PR: #33

## How can others test the changes?

- Try using the same client with multiple identities. 
- Each identity should now automatically get its own `Socket.io` connection.
- Calling `initializeSocket` manually should no longer be necessary.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).