### PR TITLE
♻️ Make the StartEventId Parameter Optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/http_contracts": "^2.3.0",
     "@essential-projects/iam_contracts": "^3.4.0",
-    "@process-engine/management_api_contracts": "^4.2.0",
+    "@process-engine/management_api_contracts": "feature~optional_start_event_id",
     "node-uuid": "^1.4.8",
     "socket.io-client": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/http_contracts": "^2.3.0",
     "@essential-projects/iam_contracts": "^3.4.0",
-    "@process-engine/management_api_contracts": "feature~optional_start_event_id",
+    "@process-engine/management_api_contracts": "^5.0.0",
     "node-uuid": "^1.4.8",
     "socket.io-client": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_client",
-  "version": "3.2.3",
+  "version": "4.0.0",
   "description": "client implementation for using the process-engine.io Management API",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -783,7 +783,7 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     restPath = `${restPath}?start_callback_type=${startCallbackType}`;
 
     const startEventIdGiven: boolean = startEventId !== undefined;
-    if (startEventId) {
+    if (startEventIdGiven) {
       restPath = `${restPath}?${restSettings.queryParams.startEventId}=${startEventId}`;
     }
 

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -308,9 +308,9 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
   public async startProcessInstance(
     identity: IIdentity,
     processModelId: string,
-    startEventId: string,
     payload: DataModels.ProcessModels.ProcessStartRequestPayload,
     startCallbackType: DataModels.ProcessModels.StartCallbackType = DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated,
+    startEventId?: string,
     endEventId?: string,
   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 
@@ -778,10 +778,14 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
   ): string {
 
     let restPath: string = restSettings.paths.startProcessInstance
-      .replace(restSettings.params.processModelId, processModelId)
-      .replace(restSettings.params.startEventId, startEventId);
+      .replace(restSettings.params.processModelId, processModelId);
 
     restPath = `${restPath}?start_callback_type=${startCallbackType}`;
+
+    const startEventIdGiven: boolean = startEventId !== undefined;
+    if (startEventId) {
+      restPath = `${restPath}?${restSettings.queryParams.startEventId}=${startEventId}`;
+    }
 
     if (startCallbackType === DataModels.ProcessModels.StartCallbackType.CallbackOnEndEventReached) {
       restPath = `${restPath}&${restSettings.queryParams.endEventId}=${endEventId}`;

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -784,7 +784,7 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
 
     const startEventIdGiven: boolean = startEventId !== undefined;
     if (startEventIdGiven) {
-      restPath = `${restPath}?${restSettings.queryParams.startEventId}=${startEventId}`;
+      restPath = `${restPath}&${restSettings.queryParams.startEventId}=${startEventId}`;
     }
 
     if (startCallbackType === DataModels.ProcessModels.StartCallbackType.CallbackOnEndEventReached) {

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -162,13 +162,13 @@ export class InternalAccessor implements IManagementApiAccessor {
   public async startProcessInstance(
     identity: IIdentity,
     processModelId: string,
-    startEventId: string,
     payload: DataModels.ProcessModels.ProcessStartRequestPayload,
     startCallbackType: DataModels.ProcessModels.StartCallbackType = DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated,
+    startEventId?: string,
     endEventId?: string,
   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 
-    return this._managementApiService.startProcessInstance(identity, processModelId, startEventId, payload, startCallbackType, endEventId);
+    return this._managementApiService.startProcessInstance(identity, processModelId, payload, startCallbackType, startEventId, endEventId);
   }
 
   public async getStartEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {

--- a/src/management_api_client_service.ts
+++ b/src/management_api_client_service.ts
@@ -195,9 +195,9 @@ export class ManagementApiClientService implements IManagementApi {
   public async startProcessInstance(
     identity: IIdentity,
     processModelId: string,
-    startEventId: string,
     payload: DataModels.ProcessModels.ProcessStartRequestPayload,
     startCallbackType: DataModels.ProcessModels.StartCallbackType = DataModels.ProcessModels.StartCallbackType.CallbackOnProcessInstanceCreated,
+    startEventId?: string,
     endEventId?: string,
   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 
@@ -211,7 +211,7 @@ export class ManagementApiClientService implements IManagementApi {
       throw new EssentialProjectErrors.BadRequestError(`Must provide an EndEventId, when using callback type 'CallbackOnEndEventReached'!`);
     }
 
-    return this.managementApiAccessor.startProcessInstance(identity, processModelId, startEventId, payload, startCallbackType, endEventId);
+    return this.managementApiAccessor.startProcessInstance(identity, processModelId, payload, startCallbackType, startEventId, endEventId);
   }
 
   public async getStartEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {


### PR DESCRIPTION
**Changes:**

1. Makes the StartEventId Parameter on the `startProcessInstance` Method optional.
This is a breaking change, because the public methods of the client and its accessors have been changed.

**Issues:**

Related: https://github.com/process-engine/process_engine_runtime/issues/252

PR: #35 

## How can others test the changes?

Run the integration tests. 

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).