### PR TITLE
✨Additional notifications for activities

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/management_api_contracts": "feature~additional_notifications_for_activities",
+    "@process-engine/management_api_contracts": "10.0.0-fd227177-b16",
     "loggerhythm": "^3.0.4",
     "node-uuid": "^1.4.8",
     "socket.io-client": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
     "@process-engine/management_api_contracts": "feature~additional_notifications_for_activities",
+    "loggerhythm": "^3.0.4",
     "node-uuid": "^1.4.8",
     "socket.io-client": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/management_api_contracts": "10.0.0-423219a7-b15",
+    "@process-engine/management_api_contracts": "feature~additional_notifications_for_activities",
     "node-uuid": "^1.4.8",
     "socket.io-client": "^2.2.0"
   },

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -69,6 +69,26 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return this.createSocketIoSubscription(identity, socketSettings.paths.activityFinished, callback, subscribeOnce);
   }
 
+  // ------------ For backwards compatibility only
+
+  public async onCallActivityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.createSocketIoSubscription(identity, socketSettings.paths.callActivityWaiting, callback, subscribeOnce);
+  }
+
+  public async onCallActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.createSocketIoSubscription(identity, socketSettings.paths.callActivityFinished, callback, subscribeOnce);
+  }
+
+  // ------------
+
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -53,6 +53,22 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
   }
 
   // Notifications
+  public async onActivityReached(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityReachedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<any> {
+    return this.createSocketIoSubscription(identity, socketSettings.paths.activityReached, callback, subscribeOnce);
+  }
+
+  public async onActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<any> {
+    return this.createSocketIoSubscription(identity, socketSettings.paths.activityFinished, callback, subscribeOnce);
+  }
+
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
@@ -167,24 +183,6 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
   ): Promise<Subscription> {
 
     return this.createSocketIoSubscription(identity, socketSettings.paths.intermediateCatchEventFinished, callback, subscribeOnce);
-  }
-
-  public async onCallActivityWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-
-    return this.createSocketIoSubscription(identity, socketSettings.paths.callActivityWaiting, callback, subscribeOnce);
-  }
-
-  public async onCallActivityFinished(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-
-    return this.createSocketIoSubscription(identity, socketSettings.paths.callActivityFinished, callback, subscribeOnce);
   }
 
   public async onManualTaskWaiting(

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -14,6 +14,22 @@ export class InternalAccessor implements IManagementApiAccessor {
   }
 
   // Notifications
+  public async onActivityReached(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityReachedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiService.onActivityReached(identity, callback, subscribeOnce);
+  }
+
+  public async onActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiService.onActivityFinished(identity, callback, subscribeOnce);
+  }
+
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
@@ -116,24 +132,6 @@ export class InternalAccessor implements IManagementApiAccessor {
   ): Promise<Subscription> {
 
     return this.managementApiService.onIntermediateCatchEventFinished(identity, callback, subscribeOnce);
-  }
-
-  public async onCallActivityWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-
-    return this.managementApiService.onCallActivityWaiting(identity, callback, subscribeOnce);
-  }
-
-  public async onCallActivityFinished(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-
-    return this.managementApiService.onCallActivityFinished(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskWaiting(

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -30,6 +30,26 @@ export class InternalAccessor implements IManagementApiAccessor {
     return this.managementApiService.onActivityFinished(identity, callback, subscribeOnce);
   }
 
+  // ------------ For backwards compatibility only
+
+  public async onCallActivityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiService.onCallActivityWaiting(identity, callback, subscribeOnce);
+  }
+
+  public async onCallActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.managementApiService.onCallActivityFinished(identity, callback, subscribeOnce);
+  }
+
+  // ------------
+
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,

--- a/src/management_api_client_service.ts
+++ b/src/management_api_client_service.ts
@@ -15,6 +15,26 @@ export class ManagementApiClientService implements IManagementApi {
   }
 
   // Notifications
+  public async onActivityReached(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityReachedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    this.ensureIsAuthorized(identity);
+
+    return this.managementApiAccessor.onActivityReached(identity, callback, subscribeOnce);
+  }
+
+  public async onActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    this.ensureIsAuthorized(identity);
+
+    return this.managementApiAccessor.onActivityFinished(identity, callback, subscribeOnce);
+  }
+
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
@@ -135,26 +155,6 @@ export class ManagementApiClientService implements IManagementApi {
     this.ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.onIntermediateCatchEventFinished(identity, callback, subscribeOnce);
-  }
-
-  public async onCallActivityWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-    this.ensureIsAuthorized(identity);
-
-    return this.managementApiAccessor.onCallActivityWaiting(identity, callback, subscribeOnce);
-  }
-
-  public async onCallActivityFinished(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-    this.ensureIsAuthorized(identity);
-
-    return this.managementApiAccessor.onCallActivityFinished(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskWaiting(

--- a/src/management_api_client_service.ts
+++ b/src/management_api_client_service.ts
@@ -1,3 +1,5 @@
+import {Logger} from 'loggerhythm';
+
 import * as EssentialProjectErrors from '@essential-projects/errors_ts';
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
@@ -5,6 +7,8 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 import {
   DataModels, IManagementApi, IManagementApiAccessor, Messages,
 } from '@process-engine/management_api_contracts';
+
+const logger = Logger.createLogger('processengine:management_api:client');
 
 export class ManagementApiClientService implements IManagementApi {
 
@@ -34,6 +38,34 @@ export class ManagementApiClientService implements IManagementApi {
 
     return this.managementApiAccessor.onActivityFinished(identity, callback, subscribeOnce);
   }
+
+  // ------------ For backwards compatibility only
+
+  public async onCallActivityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    this.ensureIsAuthorized(identity);
+
+    logger.warn('"onCallActivityWaiting" is deprecated and will be removed with the next major release! Use "onActivityReached" instead!');
+
+    return this.managementApiAccessor.onCallActivityWaiting(identity, callback, subscribeOnce);
+  }
+
+  public async onCallActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    this.ensureIsAuthorized(identity);
+
+    logger.warn('"onCallActivityFinished" is deprecated and will be removed with the next major release! Use "onActivityFinished" instead!');
+
+    return this.managementApiAccessor.onCallActivityFinished(identity, callback, subscribeOnce);
+  }
+
+  // ------------
 
   public async onEmptyActivityWaiting(
     identity: IIdentity,


### PR DESCRIPTION
## Changes

1. Refactor notification subscriptions `onCallActivityWaiting` to `onActivityReached` and `onCallActivityFinished` to `onActivityFinished`.
2. Generalize activity subscription paths, messages and types.
    - This will allow the user to susbcribe to notifications about more than just CallActivities, but also ScriptTasks, SendTasks, ReceiveTasks, ServiceTasks and Subprocesses.
3. Mark `onCallActivityWaiting` and `onCallActivityFinished` as deprecated.
    - The notifications will be removed with the next major release, to give people time to properly adjust their usage of the notifications.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/349

PR: #42

## How to test the changes

- Create Subscriptions for `onActivityReached` and `onActivityFinished`
- The corresponding callbacks will be triggered, when any kind of activity is reached or finished

