### PR TITLE
♻️ Split components into separate services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_client",
-  "version": "5.4.1",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
@@ -68,9 +68,9 @@
       "integrity": "sha512-BO8rvdz5TAivDqT+I0At55eLe5XORO98rXGIiXl5+p9cXoyh2VMlSJChgAYYZs1DYKBmSTyZCb/Ptk82Hh9S2Q=="
     },
     "@process-engine/management_api_contracts": {
-      "version": "12.0.0-5cf6489b-b5",
-      "resolved": "https://registry.npmjs.org/@process-engine/management_api_contracts/-/management_api_contracts-12.0.0-5cf6489b-b5.tgz",
-      "integrity": "sha512-M15rIWLvAtVE5ucvIirdNdB5WB1bWIL5KLaZk3TNUs2dmBPIKQskvPVS7tYU4ab8aWJoziRts61iaqikc4PwRQ==",
+      "version": "12.0.0-543ede53-b22",
+      "resolved": "https://registry.npmjs.org/@process-engine/management_api_contracts/-/management_api_contracts-12.0.0-543ede53-b22.tgz",
+      "integrity": "sha512-2qpJP1PaWnJVA5fHB28oyWrE0xi6Mq9r4da1HWyx41zyzqe4xSeFJFwkHHhBWvmgVnXtjKYij6+PZbB0q05hQQ==",
       "requires": {
         "@essential-projects/event_aggregator_contracts": "^4.0.2",
         "@essential-projects/http_contracts": "^2.3.0",
@@ -89,9 +89,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.3.tgz",
-          "integrity": "sha512-7TEYTQT1/6PP53NftXXabIZDaZfaoBdeBm8Md/i7zsWRoBe0YwOXguyK8vhHs8ehgB/w9U4K/6EWuTyp0W6nIA=="
+          "version": "12.6.9",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
+          "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
         }
       }
     },
@@ -104,9 +104,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.3.tgz",
-          "integrity": "sha512-7TEYTQT1/6PP53NftXXabIZDaZfaoBdeBm8Md/i7zsWRoBe0YwOXguyK8vhHs8ehgB/w9U4K/6EWuTyp0W6nIA=="
+          "version": "12.6.9",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
+          "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
         }
       }
     },
@@ -136,11 +136,17 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.3.tgz",
-          "integrity": "sha512-7TEYTQT1/6PP53NftXXabIZDaZfaoBdeBm8Md/i7zsWRoBe0YwOXguyK8vhHs8ehgB/w9U4K/6EWuTyp0W6nIA=="
+          "version": "12.6.9",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
+          "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
         }
       }
+    },
+    "@types/json-schema": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
+      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "dev": true
     },
     "@types/mime": {
       "version": "2.0.1",
@@ -148,9 +154,9 @@
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
-      "version": "10.14.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.12.tgz",
-      "integrity": "sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg=="
+      "version": "10.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.14.tgz",
+      "integrity": "sha512-xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -175,9 +181,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.3.tgz",
-          "integrity": "sha512-7TEYTQT1/6PP53NftXXabIZDaZfaoBdeBm8Md/i7zsWRoBe0YwOXguyK8vhHs8ehgB/w9U4K/6EWuTyp0W6nIA=="
+          "version": "12.6.9",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
+          "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
         }
       }
     },
@@ -200,12 +206,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.12.0.tgz",
-      "integrity": "sha512-J/ZTZF+pLNqjXBGNfq5fahsoJ4vJOkYbitWPavA05IrZ7BXUaf4XWlhUB/ic1lpOGTRpLWF+PLAePjiHp6dz8g==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz",
+      "integrity": "sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "1.12.0",
+        "@typescript-eslint/experimental-utils": "1.13.0",
         "eslint-utils": "^1.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^2.0.1",
@@ -213,31 +219,32 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.12.0.tgz",
-      "integrity": "sha512-s0soOTMJloytr9GbPteMLNiO2HvJ+qgQkRNplABXiVw6vq7uQRvidkby64Gqt/nA7pys74HksHwRULaB/QRVyw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "1.12.0",
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "1.13.0",
         "eslint-scope": "^4.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.12.0.tgz",
-      "integrity": "sha512-0uzbaa9ZLCA5yMWJywnJJ7YVENKGWVUhJDV5UrMoldC5HoI54W5kkdPhTfmtFKpPFp93MIwmJj0/61ztvmz5Dw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
+      "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "1.12.0",
-        "@typescript-eslint/typescript-estree": "1.12.0",
+        "@typescript-eslint/experimental-utils": "1.13.0",
+        "@typescript-eslint/typescript-estree": "1.13.0",
         "eslint-visitor-keys": "^1.0.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.12.0.tgz",
-      "integrity": "sha512-nwN6yy//XcVhFs0ZyU+teJHB8tbCm7AIA8mu6E2r5hu6MajwYBY3Uwop7+rPZWUN/IUOHpL8C+iUPMDVYUU3og==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+      "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.1",
@@ -245,9 +252,9 @@
       }
     },
     "acorn": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
-      "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+      "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
       "dev": true
     },
     "acorn-jsx": {
@@ -540,9 +547,9 @@
       }
     },
     "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
     "engine.io-client": {
@@ -746,9 +753,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
-      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
@@ -776,9 +783,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.0.tgz",
-      "integrity": "sha512-PZpAEC4gj/6DEMMoU2Df01C5c50r7zdGIN52Yfi7CvvWaYssG7Jt5R9nFG5gmqodxNOz9vQS87xk6Izdtpdrig==",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -788,8 +795,8 @@
         "eslint-import-resolver-node": "^0.3.2",
         "eslint-module-utils": "^2.4.0",
         "has": "^1.0.3",
-        "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
         "read-pkg-up": "^2.0.0",
         "resolve": "^1.11.0"
       },
@@ -894,9 +901,9 @@
       "dev": true
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "external-editor": {
@@ -1281,9 +1288,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.unescape": {
@@ -1428,6 +1435,18 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
       "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.values": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -1615,9 +1634,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
-      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -1672,9 +1691,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -1896,15 +1915,15 @@
       }
     },
     "table": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.2.tgz",
-      "integrity": "sha512-DQqgZw837CvGJ/IDqjHX3ZCY9RWlB3jEpbPURQaTMZPbuYEV+F58RGfPG1WMvghzXKFQyvIShcD4bSLiIkkuUg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
+      "integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
       "dev": true,
       "requires": {
         "ajv": "^6.10.2",
         "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
-        "string-width": "^4.1.0"
+        "string-width": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1913,21 +1932,15 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
         "string-width": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
-          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -1995,9 +2008,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.0.tgz",
-      "integrity": "sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.1.tgz",
+      "integrity": "sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,11 +68,12 @@
       "integrity": "sha512-BO8rvdz5TAivDqT+I0At55eLe5XORO98rXGIiXl5+p9cXoyh2VMlSJChgAYYZs1DYKBmSTyZCb/Ptk82Hh9S2Q=="
     },
     "@process-engine/management_api_contracts": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@process-engine/management_api_contracts/-/management_api_contracts-11.0.1.tgz",
-      "integrity": "sha512-v74yA69YmgmHF0MeCE2TRLVeSK1EFdeRGI0HU/5o1CNJX4iZZ77eyBkQvohhCyqDAxhjCVqlCKA+wVgtE2vgxQ==",
+      "version": "12.0.0-5cf6489b-b5",
+      "resolved": "https://registry.npmjs.org/@process-engine/management_api_contracts/-/management_api_contracts-12.0.0-5cf6489b-b5.tgz",
+      "integrity": "sha512-M15rIWLvAtVE5ucvIirdNdB5WB1bWIL5KLaZk3TNUs2dmBPIKQskvPVS7tYU4ab8aWJoziRts61iaqikc4PwRQ==",
       "requires": {
         "@essential-projects/event_aggregator_contracts": "^4.0.2",
+        "@essential-projects/http_contracts": "^2.3.0",
         "@essential-projects/iam_contracts": "^3.5.0",
         "@types/express": "^4.16.1",
         "@types/node": "^10.12.2"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/management_api_contracts": "feature~split_components_into_separate_services",
+    "@process-engine/management_api_contracts": "12.0.0-543ede53-b22",
     "loggerhythm": "^3.0.4",
     "moment": "^2.24.0",
     "node-uuid": "^1.4.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_client",
-  "version": "5.4.1",
+  "version": "6.0.0",
   "description": "client implementation for using the process-engine.io Management API",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/management_api_contracts": "^11.0.0",
+    "@process-engine/management_api_contracts": "feature~split_components_into_separate_services",
     "loggerhythm": "^3.0.4",
     "moment": "^2.24.0",
     "node-uuid": "^1.4.8",

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -2,15 +2,50 @@ import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {
-  DataModels, IManagementApi, IManagementApiAccessor, Messages,
+  APIs, DataModels, IManagementApiAccessor, Messages,
 } from '@process-engine/management_api_contracts';
 
 export class InternalAccessor implements IManagementApiAccessor {
 
-  private managementApiService: IManagementApi = undefined;
+  private correlationService: APIs.ICorrelationManagementApi;
+  private cronjobService: APIs.ICronjobManagementApi;
+  private emptyActivityService: APIs.IEmptyActivityManagementApi;
+  private eventService: APIs.IEventManagementApi;
+  private flowNodeInstanceService: APIs.IFlowNodeInstanceManagementApi;
+  private kpiService: APIs.IKpiManagementApi;
+  private loggingService: APIs.ILoggingManagementApi;
+  private manualTaskService: APIs.IManualTaskManagementApi;
+  private notificationService: APIs.INotificationManagementApi;
+  private processModelService: APIs.IProcessModelManagementApi;
+  private tokenHistoryService: APIs.ITokenHistoryManagementApi;
+  private userTaskService: APIs.IUserTaskManagementApi;
 
-  constructor(managementApiService: IManagementApi) {
-    this.managementApiService = managementApiService;
+  constructor(
+    correlationService: APIs.ICorrelationManagementApi,
+    cronjobService: APIs.ICronjobManagementApi,
+    emptyActivityService: APIs.IEmptyActivityManagementApi,
+    eventService: APIs.IEventManagementApi,
+    flowNodeInstanceService: APIs.IFlowNodeInstanceManagementApi,
+    kpiService: APIs.IKpiManagementApi,
+    loggingService: APIs.ILoggingManagementApi,
+    manualTaskService: APIs.IManualTaskManagementApi,
+    notificationService: APIs.INotificationManagementApi,
+    processModelService: APIs.IProcessModelManagementApi,
+    tokenHistoryService: APIs.ITokenHistoryManagementApi,
+    userTaskService: APIs.IUserTaskManagementApi,
+  ) {
+    this.correlationService = correlationService;
+    this.cronjobService = cronjobService;
+    this.emptyActivityService = emptyActivityService;
+    this.eventService = eventService;
+    this.flowNodeInstanceService = flowNodeInstanceService;
+    this.kpiService = kpiService;
+    this.loggingService = loggingService;
+    this.manualTaskService = manualTaskService;
+    this.notificationService = notificationService;
+    this.processModelService = processModelService;
+    this.tokenHistoryService = tokenHistoryService;
+    this.userTaskService = userTaskService;
   }
 
   // Notifications
@@ -19,7 +54,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnActivityReachedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    return this.managementApiService.onActivityReached(identity, callback, subscribeOnce);
+    return this.notificationService.onActivityReached(identity, callback, subscribeOnce);
   }
 
   public async onActivityFinished(
@@ -27,35 +62,15 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnActivityFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    return this.managementApiService.onActivityFinished(identity, callback, subscribeOnce);
+    return this.notificationService.onActivityFinished(identity, callback, subscribeOnce);
   }
-
-  // ------------ For backwards compatibility only
-
-  public async onCallActivityWaiting(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-    return this.managementApiService.onCallActivityWaiting(identity, callback, subscribeOnce);
-  }
-
-  public async onCallActivityFinished(
-    identity: IIdentity,
-    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
-    subscribeOnce: boolean = false,
-  ): Promise<Subscription> {
-    return this.managementApiService.onCallActivityFinished(identity, callback, subscribeOnce);
-  }
-
-  // ------------
 
   public async onEmptyActivityWaiting(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    return this.managementApiService.onEmptyActivityWaiting(identity, callback, subscribeOnce);
+    return this.notificationService.onEmptyActivityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onEmptyActivityFinished(
@@ -63,7 +78,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnEmptyActivityFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    return this.managementApiService.onEmptyActivityFinished(identity, callback, subscribeOnce);
+    return this.notificationService.onEmptyActivityFinished(identity, callback, subscribeOnce);
   }
 
   public async onEmptyActivityForIdentityWaiting(
@@ -71,7 +86,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnEmptyActivityWaitingCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    return this.managementApiService.onEmptyActivityForIdentityWaiting(identity, callback, subscribeOnce);
+    return this.notificationService.onEmptyActivityForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onEmptyActivityForIdentityFinished(
@@ -79,7 +94,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     callback: Messages.CallbackTypes.OnEmptyActivityFinishedCallback,
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
-    return this.managementApiService.onEmptyActivityForIdentityFinished(identity, callback, subscribeOnce);
+    return this.notificationService.onEmptyActivityForIdentityFinished(identity, callback, subscribeOnce);
   }
 
   public async onUserTaskWaiting(
@@ -88,7 +103,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onUserTaskWaiting(identity, callback, subscribeOnce);
+    return this.notificationService.onUserTaskWaiting(identity, callback, subscribeOnce);
   }
 
   public async onUserTaskFinished(
@@ -97,7 +112,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onUserTaskFinished(identity, callback, subscribeOnce);
+    return this.notificationService.onUserTaskFinished(identity, callback, subscribeOnce);
   }
 
   public async onUserTaskForIdentityWaiting(
@@ -106,7 +121,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
+    return this.notificationService.onUserTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onUserTaskForIdentityFinished(
@@ -115,7 +130,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
+    return this.notificationService.onUserTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
   public async onBoundaryEventTriggered(
@@ -124,7 +139,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onBoundaryEventTriggered(identity, callback, subscribeOnce);
+    return this.notificationService.onBoundaryEventTriggered(identity, callback, subscribeOnce);
   }
 
   public async onIntermediateThrowEventTriggered(
@@ -133,7 +148,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onIntermediateThrowEventTriggered(identity, callback, subscribeOnce);
+    return this.notificationService.onIntermediateThrowEventTriggered(identity, callback, subscribeOnce);
   }
 
   public async onIntermediateCatchEventReached(
@@ -142,7 +157,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onIntermediateCatchEventReached(identity, callback, subscribeOnce);
+    return this.notificationService.onIntermediateCatchEventReached(identity, callback, subscribeOnce);
   }
 
   public async onIntermediateCatchEventFinished(
@@ -151,7 +166,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onIntermediateCatchEventFinished(identity, callback, subscribeOnce);
+    return this.notificationService.onIntermediateCatchEventFinished(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskWaiting(
@@ -160,7 +175,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onManualTaskWaiting(identity, callback, subscribeOnce);
+    return this.notificationService.onManualTaskWaiting(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskFinished(
@@ -169,7 +184,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onManualTaskFinished(identity, callback, subscribeOnce);
+    return this.notificationService.onManualTaskFinished(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskForIdentityWaiting(
@@ -178,7 +193,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
+    return this.notificationService.onManualTaskForIdentityWaiting(identity, callback, subscribeOnce);
   }
 
   public async onManualTaskForIdentityFinished(
@@ -187,7 +202,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
+    return this.notificationService.onManualTaskForIdentityFinished(identity, callback, subscribeOnce);
   }
 
   public async onProcessStarted(
@@ -196,7 +211,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onProcessStarted(identity, callback, subscribeOnce);
+    return this.notificationService.onProcessStarted(identity, callback, subscribeOnce);
   }
 
   public async onProcessWithProcessModelIdStarted(
@@ -206,7 +221,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onProcessWithProcessModelIdStarted(identity, callback, processModelId, subscribeOnce);
+    return this.notificationService.onProcessWithProcessModelIdStarted(identity, callback, processModelId, subscribeOnce);
   }
 
   public async onProcessTerminated(
@@ -215,7 +230,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onProcessTerminated(identity, callback, subscribeOnce);
+    return this.notificationService.onProcessTerminated(identity, callback, subscribeOnce);
   }
 
   public async onProcessError(
@@ -224,7 +239,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onProcessError(identity, callback, subscribeOnce);
+    return this.notificationService.onProcessError(identity, callback, subscribeOnce);
   }
 
   public async onProcessEnded(
@@ -233,16 +248,57 @@ export class InternalAccessor implements IManagementApiAccessor {
     subscribeOnce: boolean = false,
   ): Promise<Subscription> {
 
-    return this.managementApiService.onProcessEnded(identity, callback, subscribeOnce);
+    return this.notificationService.onProcessEnded(identity, callback, subscribeOnce);
   }
 
+  // ------------ For backwards compatibility only
+
+  public async onCallActivityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityWaitingCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.notificationService.onCallActivityWaiting(identity, callback, subscribeOnce);
+  }
+
+  public async onCallActivityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnCallActivityFinishedCallback,
+    subscribeOnce: boolean = false,
+  ): Promise<Subscription> {
+    return this.notificationService.onCallActivityFinished(identity, callback, subscribeOnce);
+  }
+
+  // ------------
+
   public async removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
-    return this.managementApiService.removeSubscription(identity, subscription);
+    return this.notificationService.removeSubscription(identity, subscription);
+  }
+
+  // Correlations
+  public async getAllCorrelations(identity: IIdentity): Promise<Array<DataModels.Correlations.Correlation>> {
+    return this.correlationService.getAllCorrelations(identity);
+  }
+
+  public async getActiveCorrelations(identity: IIdentity): Promise<Array<DataModels.Correlations.Correlation>> {
+    return this.correlationService.getActiveCorrelations(identity);
+  }
+
+  public async getCorrelationById(identity: IIdentity, correlationId: string): Promise<DataModels.Correlations.Correlation> {
+    return this.correlationService.getCorrelationById(identity, correlationId);
+  }
+
+  public async getCorrelationByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<DataModels.Correlations.Correlation> {
+    return this.correlationService.getCorrelationByProcessInstanceId(identity, processInstanceId);
+  }
+
+  public async getCorrelationsByProcessModelId(identity: IIdentity, processModelId: string): Promise<Array<DataModels.Correlations.Correlation>> {
+    return this.correlationService.getCorrelationsByProcessModelId(identity, processModelId);
   }
 
   // Cronjobs
   public async getAllActiveCronjobs(identity: IIdentity): Promise<Array<DataModels.Cronjobs.CronjobConfiguration>> {
-    return this.managementApiService.getAllActiveCronjobs(identity);
+    return this.cronjobService.getAllActiveCronjobs(identity);
   }
 
   public async getCronjobExecutionHistoryForProcessModel(
@@ -250,48 +306,44 @@ export class InternalAccessor implements IManagementApiAccessor {
     processModelId: string,
     startEventId?: string,
   ): Promise<Array<DataModels.Cronjobs.CronjobHistoryEntry>> {
-    return this.managementApiService.getCronjobExecutionHistoryForProcessModel(identity, processModelId, startEventId);
+    return this.cronjobService.getCronjobExecutionHistoryForProcessModel(identity, processModelId, startEventId);
   }
 
   public async getCronjobExecutionHistoryForCrontab(
     identity: IIdentity,
     crontab: string,
   ): Promise<Array<DataModels.Cronjobs.CronjobHistoryEntry>> {
-    return this.managementApiService.getCronjobExecutionHistoryForCrontab(identity, crontab);
-  }
-
-  // Correlations
-  public async getAllCorrelations(identity: IIdentity): Promise<Array<DataModels.Correlations.Correlation>> {
-    return this.managementApiService.getAllCorrelations(identity);
-  }
-
-  public async getActiveCorrelations(identity: IIdentity): Promise<Array<DataModels.Correlations.Correlation>> {
-    return this.managementApiService.getActiveCorrelations(identity);
-  }
-
-  public async getCorrelationById(identity: IIdentity, correlationId: string): Promise<DataModels.Correlations.Correlation> {
-    return this.managementApiService.getCorrelationById(identity, correlationId);
-  }
-
-  public async getCorrelationByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<DataModels.Correlations.Correlation> {
-    return this.managementApiService.getCorrelationByProcessInstanceId(identity, processInstanceId);
-  }
-
-  public async getCorrelationsByProcessModelId(identity: IIdentity, processModelId: string): Promise<Array<DataModels.Correlations.Correlation>> {
-    return this.managementApiService.getCorrelationsByProcessModelId(identity, processModelId);
+    return this.cronjobService.getCronjobExecutionHistoryForCrontab(identity, crontab);
   }
 
   // ProcessModels
   public async getProcessModels(identity: IIdentity): Promise<DataModels.ProcessModels.ProcessModelList> {
-    return this.managementApiService.getProcessModels(identity);
+    return this.processModelService.getProcessModels(identity);
   }
 
   public async getProcessModelById(identity: IIdentity, processModelId: string): Promise<DataModels.ProcessModels.ProcessModel> {
-    return this.managementApiService.getProcessModelById(identity, processModelId);
+    return this.processModelService.getProcessModelById(identity, processModelId);
   }
 
   public async getProcessModelByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<DataModels.ProcessModels.ProcessModel> {
-    return this.managementApiService.getProcessModelByProcessInstanceId(identity, processInstanceId);
+    return this.processModelService.getProcessModelByProcessInstanceId(identity, processInstanceId);
+  }
+
+  public async getStartEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
+    return this.processModelService.getStartEventsForProcessModel(identity, processModelId);
+  }
+
+  public async updateProcessDefinitionsByName(
+    identity: IIdentity,
+    name: string,
+    payload: DataModels.ProcessModels.UpdateProcessDefinitionsRequestPayload,
+  ): Promise<void> {
+
+    return this.processModelService.updateProcessDefinitionsByName(identity, name, payload);
+  }
+
+  public async deleteProcessDefinitionsByProcessModelId(identity: IIdentity, processModelId: string): Promise<void> {
+    return this.processModelService.deleteProcessDefinitionsByProcessModelId(identity, processModelId);
   }
 
   public async startProcessInstance(
@@ -303,33 +355,24 @@ export class InternalAccessor implements IManagementApiAccessor {
     endEventId?: string,
   ): Promise<DataModels.ProcessModels.ProcessStartResponsePayload> {
 
-    return this.managementApiService.startProcessInstance(identity, processModelId, payload, startCallbackType, startEventId, endEventId);
+    return this.processModelService.startProcessInstance(identity, processModelId, payload, startCallbackType, startEventId, endEventId);
   }
 
-  public async getStartEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
-    return this.managementApiService.getStartEventsForProcessModel(identity, processModelId);
-  }
-
-  public async updateProcessDefinitionsByName(
+  public async terminateProcessInstance(
     identity: IIdentity,
-    name: string,
-    payload: DataModels.ProcessModels.UpdateProcessDefinitionsRequestPayload,
+    processInstanceId: string,
   ): Promise<void> {
 
-    return this.managementApiService.updateProcessDefinitionsByName(identity, name, payload);
-  }
-
-  public async deleteProcessDefinitionsByProcessModelId(identity: IIdentity, processModelId: string): Promise<void> {
-    return this.managementApiService.deleteProcessDefinitionsByProcessModelId(identity, processModelId);
+    return this.processModelService.terminateProcessInstance(identity, processInstanceId);
   }
 
   // Events
   public async getWaitingEventsForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.Events.EventList> {
-    return this.managementApiService.getWaitingEventsForProcessModel(identity, processModelId);
+    return this.eventService.getWaitingEventsForProcessModel(identity, processModelId);
   }
 
   public async getWaitingEventsForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.Events.EventList> {
-    return this.managementApiService.getWaitingEventsForCorrelation(identity, correlationId);
+    return this.eventService.getWaitingEventsForCorrelation(identity, correlationId);
   }
 
   public async getWaitingEventsForProcessModelInCorrelation(
@@ -338,31 +381,31 @@ export class InternalAccessor implements IManagementApiAccessor {
     correlationId: string,
   ): Promise<DataModels.Events.EventList> {
 
-    return this.managementApiService.getWaitingEventsForProcessModelInCorrelation(identity, processModelId, correlationId);
+    return this.eventService.getWaitingEventsForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
   public async triggerMessageEvent(identity: IIdentity, messageName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
-    return this.managementApiService.triggerMessageEvent(identity, messageName, payload);
+    return this.eventService.triggerMessageEvent(identity, messageName, payload);
   }
 
   public async triggerSignalEvent(identity: IIdentity, signalName: string, payload?: DataModels.Events.EventTriggerPayload): Promise<void> {
-    return this.managementApiService.triggerSignalEvent(identity, signalName, payload);
+    return this.eventService.triggerSignalEvent(identity, signalName, payload);
   }
 
   // Empty Activities
   public async getEmptyActivitiesForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    return this.managementApiService.getEmptyActivitiesForProcessModel(identity, processModelId);
+    return this.emptyActivityService.getEmptyActivitiesForProcessModel(identity, processModelId);
   }
 
   public async getEmptyActivitiesForProcessInstance(
     identity: IIdentity,
     processInstanceId: string,
   ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    return this.managementApiService.getEmptyActivitiesForProcessInstance(identity, processInstanceId);
+    return this.emptyActivityService.getEmptyActivitiesForProcessInstance(identity, processInstanceId);
   }
 
   public async getEmptyActivitiesForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    return this.managementApiService.getEmptyActivitiesForCorrelation(identity, correlationId);
+    return this.emptyActivityService.getEmptyActivitiesForCorrelation(identity, correlationId);
   }
 
   public async getEmptyActivitiesForProcessModelInCorrelation(
@@ -370,7 +413,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     processModelId: string,
     correlationId: string,
   ): Promise<DataModels.EmptyActivities.EmptyActivityList> {
-    return this.managementApiService.getEmptyActivitiesForProcessModelInCorrelation(identity, processModelId, correlationId);
+    return this.emptyActivityService.getEmptyActivitiesForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
   public async finishEmptyActivity(
@@ -379,7 +422,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     correlationId: string,
     emptyActivityInstanceId: string,
   ): Promise<void> {
-    return this.managementApiService.finishEmptyActivity(identity, processInstanceId, correlationId, emptyActivityInstanceId);
+    return this.emptyActivityService.finishEmptyActivity(identity, processInstanceId, correlationId, emptyActivityInstanceId);
   }
 
   // FlowNodeInstances
@@ -388,20 +431,52 @@ export class InternalAccessor implements IManagementApiAccessor {
     processInstanceId: string,
   ): Promise<Array<DataModels.FlowNodeInstances.FlowNodeInstance>> {
 
-    return this.managementApiService.getFlowNodeInstancesForProcessInstance(identity, processInstanceId);
+    return this.flowNodeInstanceService.getFlowNodeInstancesForProcessInstance(identity, processInstanceId);
+  }
+
+  // ManualTasks
+  public async getManualTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+    return this.manualTaskService.getManualTasksForProcessModel(identity, processModelId);
+  }
+
+  public async getManualTasksForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+    return this.manualTaskService.getManualTasksForProcessInstance(identity, processInstanceId);
+  }
+
+  public async getManualTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
+    return this.manualTaskService.getManualTasksForCorrelation(identity, correlationId);
+  }
+
+  public async getManualTasksForProcessModelInCorrelation(
+    identity: IIdentity,
+    processModelId: string,
+    correlationId: string,
+  ): Promise<DataModels.ManualTasks.ManualTaskList> {
+
+    return this.manualTaskService.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
+  }
+
+  public async finishManualTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    manualTaskInstanceId: string,
+  ): Promise<void> {
+
+    return this.manualTaskService.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
   }
 
   // UserTasks
   public async getUserTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    return this.managementApiService.getUserTasksForProcessModel(identity, processModelId);
+    return this.userTaskService.getUserTasksForProcessModel(identity, processModelId);
   }
 
   public async getUserTasksForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    return this.managementApiService.getUserTasksForProcessInstance(identity, processInstanceId);
+    return this.userTaskService.getUserTasksForProcessInstance(identity, processInstanceId);
   }
 
   public async getUserTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.UserTasks.UserTaskList> {
-    return this.managementApiService.getUserTasksForCorrelation(identity, correlationId);
+    return this.userTaskService.getUserTasksForCorrelation(identity, correlationId);
   }
 
   public async getUserTasksForProcessModelInCorrelation(
@@ -410,7 +485,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     correlationId: string,
   ): Promise<DataModels.UserTasks.UserTaskList> {
 
-    return this.managementApiService.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
+    return this.userTaskService.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
   }
 
   public async finishUserTask(
@@ -421,39 +496,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     userTaskResult: DataModels.UserTasks.UserTaskResult,
   ): Promise<void> {
 
-    return this.managementApiService.finishUserTask(identity, processInstanceId, correlationId, userTaskInstanceId, userTaskResult);
-  }
-
-  // ManualTasks
-  public async getManualTasksForProcessModel(identity: IIdentity, processModelId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-    return this.managementApiService.getManualTasksForProcessModel(identity, processModelId);
-  }
-
-  public async getManualTasksForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-    return this.managementApiService.getManualTasksForProcessInstance(identity, processInstanceId);
-  }
-
-  public async getManualTasksForCorrelation(identity: IIdentity, correlationId: string): Promise<DataModels.ManualTasks.ManualTaskList> {
-    return this.managementApiService.getManualTasksForCorrelation(identity, correlationId);
-  }
-
-  public async getManualTasksForProcessModelInCorrelation(
-    identity: IIdentity,
-    processModelId: string,
-    correlationId: string,
-  ): Promise<DataModels.ManualTasks.ManualTaskList> {
-
-    return this.managementApiService.getManualTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
-  }
-
-  public async finishManualTask(
-    identity: IIdentity,
-    processInstanceId: string,
-    correlationId: string,
-    manualTaskInstanceId: string,
-  ): Promise<void> {
-
-    return this.managementApiService.finishManualTask(identity, processInstanceId, correlationId, manualTaskInstanceId);
+    return this.userTaskService.finishUserTask(identity, processInstanceId, correlationId, userTaskInstanceId, userTaskResult);
   }
 
   // Heatmap related features
@@ -462,7 +505,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     processModelId: string,
   ): Promise<Array<DataModels.Kpi.FlowNodeRuntimeInformation>> {
 
-    return this.managementApiService.getRuntimeInformationForProcessModel(identity, processModelId);
+    return this.kpiService.getRuntimeInformationForProcessModel(identity, processModelId);
   }
 
   public async getRuntimeInformationForFlowNode(
@@ -471,11 +514,11 @@ export class InternalAccessor implements IManagementApiAccessor {
     flowNodeId: string,
   ): Promise<DataModels.Kpi.FlowNodeRuntimeInformation> {
 
-    return this.managementApiService.getRuntimeInformationForFlowNode(identity, processModelId, flowNodeId);
+    return this.kpiService.getRuntimeInformationForFlowNode(identity, processModelId, flowNodeId);
   }
 
   public async getActiveTokensForProcessModel(identity: IIdentity, processModelId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
-    return this.managementApiService.getActiveTokensForProcessModel(identity, processModelId);
+    return this.kpiService.getActiveTokensForProcessModel(identity, processModelId);
 
   }
 
@@ -484,22 +527,22 @@ export class InternalAccessor implements IManagementApiAccessor {
     correlationId: string,
     processModelId: string,
   ): Promise<Array<DataModels.Kpi.ActiveToken>> {
-    return this.managementApiService.getActiveTokensForCorrelationAndProcessModel(identity, correlationId, processModelId);
+    return this.kpiService.getActiveTokensForCorrelationAndProcessModel(identity, correlationId, processModelId);
   }
 
   public async getActiveTokensForProcessInstance(
     identity: IIdentity,
     processInstanceId: string,
   ): Promise<Array<DataModels.Kpi.ActiveToken>> {
-    return this.managementApiService.getActiveTokensForProcessInstance(identity, processInstanceId);
+    return this.kpiService.getActiveTokensForProcessInstance(identity, processInstanceId);
   }
 
   public async getActiveTokensForFlowNode(identity: IIdentity, flowNodeId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
-    return this.managementApiService.getActiveTokensForFlowNode(identity, flowNodeId);
+    return this.kpiService.getActiveTokensForFlowNode(identity, flowNodeId);
   }
 
   public async getProcessModelLog(identity: IIdentity, processModelId: string, correlationId?: string): Promise<Array<DataModels.Logging.LogEntry>> {
-    return this.managementApiService.getProcessModelLog(identity, processModelId, correlationId);
+    return this.loggingService.getProcessModelLog(identity, processModelId, correlationId);
   }
 
   public async getProcessInstanceLog(
@@ -508,7 +551,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     processInstanceId: string,
   ): Promise<Array<DataModels.Logging.LogEntry>> {
 
-    return this.managementApiService.getProcessInstanceLog(identity, processModelId, processInstanceId);
+    return this.loggingService.getProcessInstanceLog(identity, processModelId, processInstanceId);
   }
 
   public async getTokensForFlowNode(
@@ -518,7 +561,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     flowNodeId: string,
   ): Promise<Array<DataModels.TokenHistory.TokenHistoryEntry>> {
 
-    return this.managementApiService.getTokensForFlowNode(identity, correlationId, processModelId, flowNodeId);
+    return this.tokenHistoryService.getTokensForFlowNode(identity, correlationId, processModelId, flowNodeId);
   }
 
   public async getTokensForFlowNodeByProcessInstanceId(
@@ -527,7 +570,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     flowNodeId: string,
   ): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
 
-    return this.managementApiService.getTokensForFlowNodeByProcessInstanceId(identity, processInstanceId, flowNodeId);
+    return this.tokenHistoryService.getTokensForFlowNodeByProcessInstanceId(identity, processInstanceId, flowNodeId);
   }
 
   public async getTokensForCorrelationAndProcessModel(
@@ -536,7 +579,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     processModelId: string,
   ): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
 
-    return this.managementApiService.getTokensForCorrelationAndProcessModel(identity, correlationId, processModelId);
+    return this.tokenHistoryService.getTokensForCorrelationAndProcessModel(identity, correlationId, processModelId);
   }
 
   public async getTokensForProcessInstance(
@@ -544,15 +587,7 @@ export class InternalAccessor implements IManagementApiAccessor {
     processInstanceId: string,
   ): Promise<DataModels.TokenHistory.TokenHistoryGroup> {
 
-    return this.managementApiService.getTokensForProcessInstance(identity, processInstanceId);
-  }
-
-  public async terminateProcessInstance(
-    identity: IIdentity,
-    processInstanceId: string,
-  ): Promise<void> {
-
-    return this.managementApiService.terminateProcessInstance(identity, processInstanceId);
+    return this.tokenHistoryService.getTokensForProcessInstance(identity, processInstanceId);
   }
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export * from './accessors/index';
-export * from './management_api_client_service';
+export * from './management_api_client';

--- a/src/management_api_client.ts
+++ b/src/management_api_client.ts
@@ -10,7 +10,7 @@ import {
 
 const logger = Logger.createLogger('processengine:management_api:client');
 
-export class ManagementApiClientService implements IManagementApiClient {
+export class ManagementApiClient implements IManagementApiClient {
 
   private managementApiAccessor: IManagementApiAccessor = undefined;
 

--- a/src/management_api_client_service.ts
+++ b/src/management_api_client_service.ts
@@ -5,12 +5,12 @@ import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {
-  DataModels, IManagementApi, IManagementApiAccessor, Messages,
+  DataModels, IManagementApiAccessor, IManagementApiClient, Messages,
 } from '@process-engine/management_api_contracts';
 
 const logger = Logger.createLogger('processengine:management_api:client');
 
-export class ManagementApiClientService implements IManagementApi {
+export class ManagementApiClientService implements IManagementApiClient {
 
   private managementApiAccessor: IManagementApiAccessor = undefined;
 


### PR DESCRIPTION
## Changes

1. Use `IManagementApiClient` interface for main client
2. Use refactored service structure with internal accessor
3. Remove `Service` suffix from `ManagementApiClient`

## Issues

PR: #54
