### PR TITLE
✨ Add Queries for retrieving ProcessInstances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_client",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "client implementation for using the process-engine.io Management API",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/management_api_contracts": "feature~flatten_correlation_types",
+    "@process-engine/management_api_contracts": "14.0.0-alpha.1",
     "loggerhythm": "^3.0.4",
     "moment": "^2.24.0",
     "node-uuid": "^1.4.8",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/management_api_contracts": "13.0.0-alpha.1",
+    "@process-engine/management_api_contracts": "feature~flatten_correlation_types",
     "loggerhythm": "^3.0.4",
     "moment": "^2.24.0",
     "node-uuid": "^1.4.8",

--- a/src/accessors/external_accessor.ts
+++ b/src/accessors/external_accessor.ts
@@ -385,20 +385,6 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     return httpResponse.result;
   }
 
-  public async getCorrelationByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<DataModels.Correlations.Correlation> {
-
-    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
-
-    const restPath = restSettings.paths.getCorrelationByProcessInstanceId
-      .replace(restSettings.params.processInstanceId, processInstanceId);
-
-    const url = this.buildUrl(restPath);
-
-    const httpResponse = await this.httpClient.get<DataModels.Correlations.Correlation>(url, requestAuthHeaders);
-
-    return httpResponse.result;
-  }
-
   public async getCorrelationsByProcessModelId(
     identity: IIdentity,
     processModelId: string,
@@ -414,6 +400,77 @@ export class ExternalAccessor implements IManagementApiAccessor, IManagementSock
     const url = this.buildUrl(restPath, offset, limit);
 
     const httpResponse = await this.httpClient.get<DataModels.Correlations.CorrelationList>(url, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  public async getProcessInstanceById(identity: IIdentity, processInstanceId: string): Promise<DataModels.Correlations.ProcessInstance> {
+
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const restPath = restSettings.paths.getProcessInstanceById
+      .replace(restSettings.params.processInstanceId, processInstanceId);
+
+    const url = this.buildUrl(restPath);
+
+    const httpResponse = await this.httpClient.get<DataModels.Correlations.ProcessInstance>(url, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  public async getProcessInstancesForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<DataModels.Correlations.ProcessInstanceList> {
+
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const restPath = restSettings.paths.getProcessInstancesForCorrelation
+      .replace(restSettings.params.correlationId, correlationId);
+
+    const url = this.buildUrl(restPath, offset, limit);
+
+    const httpResponse = await this.httpClient.get<DataModels.Correlations.ProcessInstanceList>(url, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  public async getProcessInstancesForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<DataModels.Correlations.ProcessInstanceList> {
+
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const restPath = restSettings.paths.getProcessInstancesForProcessModel
+      .replace(restSettings.params.processModelId, processModelId);
+
+    const url = this.buildUrl(restPath, offset, limit);
+
+    const httpResponse = await this.httpClient.get<DataModels.Correlations.ProcessInstanceList>(url, requestAuthHeaders);
+
+    return httpResponse.result;
+  }
+
+  public async getProcessInstancesByState(
+    identity: IIdentity,
+    state: DataModels.Correlations.CorrelationState,
+    offset?: number,
+    limit?: number,
+  ): Promise<DataModels.Correlations.ProcessInstanceList> {
+
+    const requestAuthHeaders = this.createRequestAuthHeaders(identity);
+
+    const restPath = restSettings.paths.getProcessInstancesByState
+      .replace(restSettings.params.processInstanceState, state);
+
+    const url = this.buildUrl(restPath, offset, limit);
+
+    const httpResponse = await this.httpClient.get<DataModels.Correlations.ProcessInstanceList>(url, requestAuthHeaders);
 
     return httpResponse.result;
   }

--- a/src/accessors/internal_accessor.ts
+++ b/src/accessors/internal_accessor.ts
@@ -321,10 +321,6 @@ export class InternalAccessor implements IManagementApiAccessor {
     return this.correlationService.getCorrelationById(identity, correlationId);
   }
 
-  public async getCorrelationByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<DataModels.Correlations.Correlation> {
-    return this.correlationService.getCorrelationByProcessInstanceId(identity, processInstanceId);
-  }
-
   public async getCorrelationsByProcessModelId(
     identity: IIdentity,
     processModelId: string,
@@ -332,6 +328,37 @@ export class InternalAccessor implements IManagementApiAccessor {
     limit: number = 0,
   ): Promise<DataModels.Correlations.CorrelationList> {
     return this.correlationService.getCorrelationsByProcessModelId(identity, processModelId, offset, limit);
+  }
+
+  public async getProcessInstanceById(identity: IIdentity, processInstanceId: string): Promise<DataModels.Correlations.ProcessInstance> {
+    return this.correlationService.getProcessInstanceById(identity, processInstanceId);
+  }
+
+  public async getProcessInstancesForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<DataModels.Correlations.ProcessInstanceList> {
+    return this.correlationService.getProcessInstancesForCorrelation(identity, correlationId, offset, limit);
+  }
+
+  public async getProcessInstancesForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<DataModels.Correlations.ProcessInstanceList> {
+    return this.correlationService.getProcessInstancesForProcessModel(identity, processModelId, offset, limit);
+  }
+
+  public async getProcessInstancesByState(
+    identity: IIdentity,
+    state: DataModels.Correlations.CorrelationState,
+    offset?: number,
+    limit?: number,
+  ): Promise<DataModels.Correlations.ProcessInstanceList> {
+    return this.correlationService.getProcessInstancesByState(identity, state, offset, limit);
   }
 
   // Cronjobs

--- a/src/management_api_client.ts
+++ b/src/management_api_client.ts
@@ -331,10 +331,10 @@ export class ManagementApiClient implements IManagementApiClient {
     return this.managementApiAccessor.getCorrelationById(identity, correlationId);
   }
 
-  public async getCorrelationByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<DataModels.Correlations.Correlation> {
+  public async getProcessInstanceById(identity: IIdentity, processInstanceId: string): Promise<DataModels.Correlations.ProcessInstance> {
     this.ensureIsAuthorized(identity);
 
-    return this.managementApiAccessor.getCorrelationByProcessInstanceId(identity, processInstanceId);
+    return this.managementApiAccessor.getProcessInstanceById(identity, processInstanceId);
   }
 
   public async getCorrelationsByProcessModelId(
@@ -346,6 +346,39 @@ export class ManagementApiClient implements IManagementApiClient {
     this.ensureIsAuthorized(identity);
 
     return this.managementApiAccessor.getCorrelationsByProcessModelId(identity, processModelId, offset, limit);
+  }
+
+  public async getProcessInstancesForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<DataModels.Correlations.ProcessInstanceList> {
+    this.ensureIsAuthorized(identity);
+
+    return this.managementApiAccessor.getProcessInstancesForCorrelation(identity, correlationId, offset, limit);
+  }
+
+  public async getProcessInstancesForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<DataModels.Correlations.ProcessInstanceList> {
+    this.ensureIsAuthorized(identity);
+
+    return this.managementApiAccessor.getProcessInstancesForProcessModel(identity, processModelId, offset, limit);
+  }
+
+  public async getProcessInstancesByState(
+    identity: IIdentity,
+    state: DataModels.Correlations.CorrelationState,
+    offset?: number,
+    limit?: number,
+  ): Promise<DataModels.Correlations.ProcessInstanceList> {
+    this.ensureIsAuthorized(identity);
+
+    return this.managementApiAccessor.getProcessInstancesByState(identity, state, offset, limit);
   }
 
   // Cronjobs


### PR DESCRIPTION
## Changes

1. Rename `getCorrelationByProcessInstanceId` to `getProcessInstanceById`
2. Add UseCases for getting ProcessInstances:
    - getProcessInstancesForCorrelation
    - getProcessInstancesForProcessModel
    - getProcessInstancesByState

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/404

PR: #58